### PR TITLE
Display `metatensor-torch` torchscript classes correctly in docs

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -10,6 +10,10 @@ import metatensor.models
 ROOT = os.path.abspath(os.path.join("..", ".."))
 sys.path.insert(0, ROOT)
 
+# when importing metatensor-torch, this will change the definition of the classes
+# to include the documentation
+os.environ["METATENSOR_IMPORT_FOR_SPHINX"] = "1"
+
 # -- Project information -----------------------------------------------------
 
 # The master toctree document.

--- a/src/metatensor/models/utils/data/dataset.py
+++ b/src/metatensor/models/utils/data/dataset.py
@@ -1,3 +1,4 @@
+import os
 from typing import Dict, List
 
 import metatensor.torch
@@ -6,8 +7,13 @@ from metatensor.torch import Labels, TensorMap
 from metatensor.torch.atomistic import ModelCapabilities, System
 
 
-compiled_slice = torch.jit.script(metatensor.torch.slice)
-compiled_join = torch.jit.script(metatensor.torch.join)
+if os.environ.get("METATENSOR_IMPORT_FOR_SPHINX", "0") == "1":
+    # This is necessary to make the Sphinx documentation build
+    compiled_slice = None
+    compiled_join = None
+else:
+    compiled_slice = torch.jit.script(metatensor.torch.slice)
+    compiled_join = torch.jit.script(metatensor.torch.join)
 
 
 class Dataset(torch.utils.data.Dataset):


### PR DESCRIPTION
Closes #20

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--40.org.readthedocs.build/en/40/

<!-- readthedocs-preview metatensor-models end -->