### PR TITLE
Clean up logging

### DIFF
--- a/src/metatensor/models/utils/info.py
+++ b/src/metatensor/models/utils/info.py
@@ -34,7 +34,9 @@ def update_aggregated_info(
     return aggregated_info
 
 
-def finalize_aggregated_info(aggregated_info):
+def finalize_aggregated_info(
+    aggregated_info: Dict[str, Tuple[float, int]]
+) -> Dict[str, float]:
     """
     Finalize the aggregated information dictionaryby calculating RMSEs.
 

--- a/src/metatensor/models/utils/logging.py
+++ b/src/metatensor/models/utils/logging.py
@@ -25,12 +25,11 @@ class MetricLogger:
 
         In this way, the logger can align the output to make it easier to read.
 
-        Args:
-            model_capabilities: The capabilities of the model.
-            train_loss_0: The initial training loss.
-            validation_loss_0: The initial validation loss.
-            train_info_0: The initial training metrics.
-            validation_info_0: The initial validation metrics.
+        :param model_capabilities: The capabilities of the model.
+        :param train_loss_0: The initial training loss.
+        :param validation_loss_0: The initial validation loss.
+        :param train_info_0: The initial training metrics.
+        :param validation_info_0: The initial validation metrics.
         """
 
         # Since the quantities are supposed to decrease, we want to store the
@@ -72,12 +71,11 @@ class MetricLogger:
         The training metrics are automatically aligned to make them easier to read,
         based on the order of magnitude of each metric at the start of the training.
 
-        Args:
-            epoch: The current epoch.
-            train_loss: The current training loss.
-            validation_loss: The current validation loss.
-            train_info: The current training metrics.
-            validation_info: The current validation metrics.
+        :param epoch: The current epoch.
+        :param train_loss: The current training loss.
+        :param validation_loss: The current validation loss.
+        :param train_info: The current training metrics.
+        :param validation_info: The current validation metrics.
         """
 
         # The epoch is printed with 4 digits, assuming that the training
@@ -132,8 +130,7 @@ def _get_digits(value: float) -> Tuple[int, int]:
 
     5 "significant" digits are guaranteed to be printed.
 
-    Args:
-        value: The value for which the number of digits is calculated.
+    :param value: The value for which the number of digits is calculated.
     """
 
     # Get order of magnitude of the value:

--- a/src/metatensor/models/utils/logging.py
+++ b/src/metatensor/models/utils/logging.py
@@ -1,0 +1,156 @@
+import logging
+from typing import Dict, Tuple
+
+import numpy as np
+from metatensor.torch.atomistic import ModelCapabilities
+
+
+logger = logging.getLogger(__name__)
+
+
+class MetricLogger:
+    """This class provides a simple interface to log training metrics to a file."""
+
+    def __init__(
+        self,
+        model_capabilities: ModelCapabilities,
+        train_loss_0: float,
+        validation_loss_0: float,
+        train_info_0: Dict[str, float],
+        validation_info_0: Dict[str, float],
+    ):
+        """
+        Initialize the logger with metrics that are supposed to
+        decrease during training.
+
+        In this way, the logger can align the output to make it easier to read.
+
+        Args:
+            model_capabilities: The capabilities of the model.
+            train_loss_0: The initial training loss.
+            validation_loss_0: The initial validation loss.
+            train_info_0: The initial training metrics.
+            validation_info_0: The initial validation metrics.
+        """
+
+        # Since the quantities are supposed to decrease, we want to store the
+        # number of digits at the start of the training, so that we can align
+        # the output later:
+        self.digits = {}
+        self.digits["train_loss"] = _get_digits(train_loss_0)
+        self.digits["validation_loss"] = _get_digits(validation_loss_0)
+        for name, information_holder in zip(
+            ["train", "valid"], [train_info_0, validation_info_0]
+        ):
+            for key, value in information_holder.items():
+                self.digits[f"{name}_{key}"] = _get_digits(value)
+
+        # This will be useful later for printing forces/virials/stresses:
+        energy_counter = 0
+        for output in model_capabilities.outputs.values():
+            if output.quantity == "energy":
+                energy_counter += 1
+        if energy_counter == 1:
+            self.only_one_energy = True
+        else:
+            self.only_one_energy = False
+
+        # Save the model capabilities for later use:
+        self.model_capabilities = model_capabilities
+
+    def log(
+        self,
+        epoch: int,
+        train_loss: float,
+        validation_loss: float,
+        train_info: Dict[str, float],
+        validation_info: Dict[str, float],
+    ):
+        """
+        Log the training metrics.
+
+        The training metrics are automatically aligned to make them easier to read,
+        based on the order of magnitude of each metric at the start of the training.
+
+        Args:
+            epoch: The current epoch.
+            train_loss: The current training loss.
+            validation_loss: The current validation loss.
+            train_info: The current training metrics.
+            validation_info: The current validation metrics.
+        """
+
+        # The epoch is printed with 4 digits, assuming that the training
+        # will not last more than 9999 epochs
+        logging_string = (
+            f"Epoch {epoch:4}, train loss: "
+            f"{train_loss:{self.digits['train_loss'][0]}.{self.digits['train_loss'][1]}f}, "  # noqa: E501
+            f"validation loss: "
+            f"{validation_loss:{self.digits['validation_loss'][0]}.{self.digits['validation_loss'][1]}f}"  # noqa: E501
+        )
+        for name, information_holder in zip(
+            ["train", "valid"], [train_info, validation_info]
+        ):
+            for key, value in information_holder.items():
+                new_key = key
+                if key.endswith("_positions_gradients"):
+                    # check if this is a force
+                    target_name = key[: -len("_positions_gradients")]
+                    if (
+                        self.model_capabilities.outputs[target_name].quantity
+                        == "energy"
+                    ):
+                        # if this is a force, replace the ugly name with "force"
+                        if self.only_one_energy:
+                            new_key = "force"
+                        else:
+                            new_key = f"force[{target_name}]"
+                elif key.endswith("_displacement_gradients"):
+                    # check if this is a virial/stress
+                    target_name = key[: -len("_displacement_gradients")]
+                    if (
+                        self.model_capabilities.outputs[target_name].quantity
+                        == "energy"
+                    ):
+                        # if this is a virial/stress,
+                        # replace the ugly name with "virial/stress"
+                        if self.only_one_energy:
+                            new_key = "virial/stress"
+                        else:
+                            new_key = f"virial/stress[{target_name}]"
+                logging_string += (
+                    f", {name} {new_key} RMSE: "
+                    f"{value:{self.digits[f'{name}_{key}'][0]}.{self.digits[f'{name}_{key}'][1]}f}"  # noqa: E501
+                )
+        logger.info(logging_string)
+
+
+def _get_digits(value: float) -> Tuple[int, int]:
+    """
+    Finds the number of digits to print before and after the decimal point,
+    based on the order of magnitude of the value.
+
+    5 "significant" digits are guaranteed to be printed.
+
+    Args:
+        value: The value for which the number of digits is calculated.
+    """
+
+    # Get order of magnitude of the value:
+    order = int(np.floor(np.log10(value)))
+
+    # Get the number of digits before the decimal point:
+    if order < 0:
+        digits_before = 1
+    else:
+        digits_before = order + 1
+
+    # Get the number of digits after the decimal point:
+    if order < 0:
+        digits_after = 4 - order
+    else:
+        digits_after = max(1, 4 - order)
+
+    total_characters = digits_before + digits_after + 1  # +1 for the point
+
+    return total_characters, digits_after


### PR DESCRIPTION
This aims to clean up the logging, according to #39.
The resulting logger can be used by several models, so it has been extracted into `utils`

Before:
```
[2024-02-02 08:54:04,880][metatensor.models.cli.train_model][INFO] - Setting up training set
[2024-02-02 08:54:04,956][metatensor.models.utils.data.readers.readers][INFO] - Forces found in section 'energy'. Forces are taken for training!
[2024-02-02 08:54:04,976][metatensor.models.utils.data.readers.readers][WARNING] - Stress not found in section 'energy'. Continue without stress!
[2024-02-02 08:54:04,977][metatensor.models.cli.train_model][INFO] - Setting up test set
[2024-02-02 08:54:04,977][metatensor.models.cli.train_model][INFO] - Setting up validation set
[2024-02-02 08:54:04,978][metatensor.models.cli.train_model][INFO] - Setting up model
[2024-02-02 08:54:05,069][metatensor.models.cli.train_model][INFO] - Calling architecture trainer
[2024-02-02 08:54:05,069][metatensor.models.soap_bpnn.train][INFO] - Checking datasets for consistency
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
[2024-02-02 08:54:05,158][metatensor.models.soap_bpnn.train][INFO] - Calculating composition weights
[2024-02-02 08:54:05,273][metatensor.models.soap_bpnn.train][INFO] - Setting up data loaders
[2024-02-02 08:54:05,424][metatensor.models.soap_bpnn.train][INFO] - Starting training
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
/home/filippo/.local/lib/python3.8/site-packages/torch/autograd/__init__.py:251: UserWarning: second derivatives with respect to positions are not implemented and will not be accumulated during backward() calls. If you need second derivatives, please open an issue on rascaline repository. (Triggered internally at /home/filippo/rascaline/rascaline-torch/src/autograd.cpp:313.)
  Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
[2024-02-02 08:54:09,217][metatensor.models.soap_bpnn.train][INFO] - Epoch    0, train loss:  4104.6695, validation loss:   614.6490, train energy RMSE:     3.8793, train force RMSE:    28.3881, valid energy RMSE:     3.3691, valid force RMSE:    24.5621
[2024-02-02 08:54:15,572][metatensor.models.soap_bpnn.train][INFO] - Epoch    5, train loss:  2332.1070, validation loss:   328.8712, train energy RMSE:     2.9285, train force RMSE:    21.3973, valid energy RMSE:     2.0911, valid force RMSE:    18.0138
[2024-02-02 08:54:21,735][metatensor.models.soap_bpnn.train][INFO] - Epoch   10, train loss:   389.5255, validation loss:    61.7523, train energy RMSE:     2.2921, train force RMSE:     8.5236, valid energy RMSE:     1.7062, valid force RMSE:     7.6708
[2024-02-02 08:54:28,088][metatensor.models.soap_bpnn.train][INFO] - Epoch   15, train loss:   148.4480, validation loss:    28.8797, train energy RMSE:     1.7587, train force RMSE:     5.1572, valid energy RMSE:     1.6739, valid force RMSE:     5.1066
[2024-02-02 08:54:34,342][metatensor.models.soap_bpnn.train][INFO] - Epoch   20, train loss:   116.4343, validation loss:    25.2689, train energy RMSE:     2.1110, train force RMSE:     4.3394, valid energy RMSE:     2.4750, valid force RMSE:     4.3753
[2024-02-02 08:54:40,748][metatensor.models.soap_bpnn.train][INFO] - Epoch   25, train loss:   103.5423, validation loss:    16.3115, train energy RMSE:     2.2714, train force RMSE:     3.9433, valid energy RMSE:     0.9048, valid force RMSE:     3.9361
```

After:
```
[2024-02-02 08:50:28,485][metatensor.models.cli.train_model][INFO] - Setting up training set
[2024-02-02 08:50:28,560][metatensor.models.utils.data.readers.readers][INFO] - Forces found in section 'energy'. Forces are taken for training!
[2024-02-02 08:50:28,582][metatensor.models.utils.data.readers.readers][WARNING] - Stress not found in section 'energy'. Continue without stress!
[2024-02-02 08:50:28,583][metatensor.models.cli.train_model][INFO] - Setting up test set
[2024-02-02 08:50:28,583][metatensor.models.cli.train_model][INFO] - Setting up validation set
[2024-02-02 08:50:28,583][metatensor.models.cli.train_model][INFO] - Setting up model
[2024-02-02 08:50:28,673][metatensor.models.cli.train_model][INFO] - Calling architecture trainer
[2024-02-02 08:50:28,674][metatensor.models.soap_bpnn.train][INFO] - Checking datasets for consistency
[2024-02-02 08:50:28,761][metatensor.models.soap_bpnn.train][INFO] - Calculating composition weights
[2024-02-02 08:50:28,875][metatensor.models.soap_bpnn.train][INFO] - Setting up data loaders
[2024-02-02 08:50:29,044][metatensor.models.soap_bpnn.train][INFO] - Starting training
[2024-02-02 08:50:32,343][metatensor.models.utils.logging][INFO] - Epoch    0, train loss: 3930.5, validation loss: 614.71, train energy RMSE: 4.0425, train force RMSE: 27.744, valid energy RMSE: 3.1709, valid force RMSE: 24.590
[2024-02-02 08:50:39,017][metatensor.models.utils.logging][INFO] - Epoch    5, train loss: 2309.8, validation loss: 330.64, train energy RMSE: 2.7989, train force RMSE: 21.310, valid energy RMSE: 1.8786, valid force RMSE: 18.086
[2024-02-02 08:50:45,312][metatensor.models.utils.logging][INFO] - Epoch   10, train loss:  319.1, validation loss:  66.38, train energy RMSE: 2.1813, train force RMSE:  7.685, valid energy RMSE: 4.0625, valid force RMSE:  7.062
[2024-02-02 08:50:51,406][metatensor.models.utils.logging][INFO] - Epoch   15, train loss:  155.8, validation loss:  34.09, train energy RMSE: 2.8850, train force RMSE:  4.779, valid energy RMSE: 2.9216, valid force RMSE:  5.056
[2024-02-02 08:50:57,619][metatensor.models.utils.logging][INFO] - Epoch   20, train loss:  106.5, validation loss:  22.33, train energy RMSE: 2.1761, train force RMSE:  4.070, valid energy RMSE: 1.4479, valid force RMSE:  4.498
[2024-02-02 08:51:03,782][metatensor.models.utils.logging][INFO] - Epoch   25, train loss:  106.5, validation loss:  17.12, train energy RMSE: 2.3252, train force RMSE:  3.988, valid energy RMSE: 1.0178, valid force RMSE:  4.011
``` 

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--45.org.readthedocs.build/en/45/

<!-- readthedocs-preview metatensor-models end -->