### PR TITLE
Add option to restart training

### DIFF
--- a/src/metatensor/models/cli/conf/architecture/soap_bpnn.yaml
+++ b/src/metatensor/models/cli/conf/architecture/soap_bpnn.yaml
@@ -2,6 +2,7 @@
 name: soap_bpnn
 
 model:
+  restart: null
   soap:
     cutoff: 5.0
     max_radial: 8

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -65,6 +65,17 @@ def test_train_explicit_validation_test(
     assert Path(output).is_file()
 
 
+def test_restart(monkeypatch, tmp_path):
+    """Test that training via the training cli runs without an error raise."""
+    monkeypatch.chdir(tmp_path)
+    shutil.copy(RESOURCES_PATH / "qm9_reduced_100.xyz", "qm9_reduced_100.xyz")
+    shutil.copy(RESOURCES_PATH / "bpnn-model.pt", "bpnn-model.pt")
+    shutil.copy(RESOURCES_PATH / "options_restart.yaml", "options_restart.yaml")
+
+    command = ["metatensor-models", "train", "options_restart.yaml"]
+    subprocess.check_call(command)
+
+
 def test_yml_error():
     """Test error raise of the option file is not a .yaml file."""
     try:

--- a/tests/resources/options_restart.yaml
+++ b/tests/resources/options_restart.yaml
@@ -1,0 +1,21 @@
+defaults:
+  - architecture: soap_bpnn  # architecture used to train the model
+  - _self_
+
+architecture:
+  model:
+    restart: bpnn-model.pt
+  training:
+    batch_size: 2
+    num_epochs: 1
+
+# Section defining the parameters for structure and target data
+training_set:
+  structures:
+    read_from: "qm9_reduced_100.xyz"
+  targets:
+    energy:
+      key: "U0"
+
+test_set: 0.1
+validation_set: 0.1


### PR DESCRIPTION
Still missing:
- dataset checks
- perhaps this is not the most user-friendly way to implement this. I'm thinking about `--restart model.pt`

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--46.org.readthedocs.build/en/46/

<!-- readthedocs-preview metatensor-models end -->