### PR TITLE
Change how eval function works

### DIFF
--- a/docs/src/getting-started/usage.rst
+++ b/docs/src/getting-started/usage.rst
@@ -66,16 +66,17 @@ The sub-command to evaluate an already trained model is
 
     metatensor-models eval
 
-Besides the trained `model` you will also have to provide a file containing
-the structure and possible target values for evaluation. The structure of this
-``eval.yaml`` is exactly the same as for a dataset in the ``options.yaml`` file.
+Besides the trained `model` you will also have to provide a file containing the
+structure and possible target values for evaluation. The structure of this ``eval.yaml``
+is exactly the same as for a dataset in the ``options.yaml`` file.
 
 .. literalinclude:: ../../static/qm9/eval.yaml
    :language: yaml
 
-Note that the ``targets`` section is optional. If the ``targets`` section is present, the
-function will calculate and report RMSE values of the predictions with respect to the
-real values as loaded from the ``targets`` section. You can run an evaluation by typing
+Note that the ``targets`` section is optional. If the ``targets`` section is present,
+the function will calculate and report RMSE values of the predictions with respect to
+the real values as loaded from the ``targets`` section. You can run an evaluation by
+typing
 
 .. literalinclude:: ../../../examples/basic_usage/usage.sh
     :language: bash
@@ -85,9 +86,8 @@ real values as loaded from the ``targets`` section. You can run an evaluation by
 Exporting
 #########
 
-Exporting a model is very useful if you want to use it in other frameworks,
-especially in molecular dynamics simulations.
-The sub-command to export a trained model is
+Exporting a model is very useful if you want to use it in other frameworks, especially
+in molecular dynamics simulations. The sub-command to export a trained model is
 
 .. code-block:: bash
 
@@ -97,5 +97,5 @@ The sub-command to export a trained model is
     :language: bash
     :lines: 26-
 
-In the next tutorials we show how adjust the dataset section of ``options.yaml`` file
-to use it for your own datasets.
+In the next tutorials we show how adjust the dataset section of ``options.yaml`` file to
+use it for your own datasets.

--- a/docs/src/getting-started/usage.rst
+++ b/docs/src/getting-started/usage.rst
@@ -66,14 +66,14 @@ The sub-command to evaluate an already trained model is
 
     metatensor-models eval
 
-Besides the a already trained `model` you will also have to provide a file containing
+Besides the trained `model` you will also have to provide a file containing
 the structure and possible target values for evaluation. The structure of this
 ``eval.yaml`` is exactly the same as for a dataset in the ``options.yaml`` file.
 
 .. literalinclude:: ../../static/qm9/eval.yaml
    :language: yaml
 
-Note that the ``targets`` section is optional. If the ``targets`` section is present the
+Note that the ``targets`` section is optional. If the ``targets`` section is present, the
 function will calculate and report RMSE values of the predictions with respect to the
 real values as loaded from the ``targets`` section. You can run an evaluation by typing
 

--- a/docs/src/getting-started/usage.rst
+++ b/docs/src/getting-started/usage.rst
@@ -66,9 +66,20 @@ The sub-command to evaluate an already trained model is
 
     metatensor-models eval
 
+Besides the a already trained `model` you will also have to provide a file containing
+the structure and possible target values for evaluation. The structure of this
+``eval.yaml`` is exactly the same as for a dataset in the ``options.yaml`` file.
+
+.. literalinclude:: ../../static/qm9/eval.yaml
+   :language: yaml
+
+Note that the ``targets`` section is optional. If the ``targets`` section is present the
+function will calculate and report RMSE values of the predictions with respect to the
+real values as loaded from the ``targets`` section. You can run an evaluation by typing
+
 .. literalinclude:: ../../../examples/basic_usage/usage.sh
     :language: bash
-    :lines: 9-25
+    :lines: 9-24
 
 
 Exporting
@@ -84,7 +95,7 @@ The sub-command to export a trained model is
 
 .. literalinclude:: ../../../examples/basic_usage/usage.sh
     :language: bash
-    :lines: 25-
+    :lines: 26-
 
 In the next tutorials we show how adjust the dataset section of ``options.yaml`` file
 to use it for your own datasets.

--- a/docs/src/getting-started/usage.rst
+++ b/docs/src/getting-started/usage.rst
@@ -66,7 +66,7 @@ The sub-command to evaluate an already trained model is
 
     metatensor-models eval
 
-Besides the trained `model` you will also have to provide a file containing the
+Besides the trained `model`, you will also have to provide a file containing the
 structure and possible target values for evaluation. The structure of this ``eval.yaml``
 is exactly the same as for a dataset in the ``options.yaml`` file.
 

--- a/docs/static/qm9/eval.yaml
+++ b/docs/static/qm9/eval.yaml
@@ -1,0 +1,4 @@
+structures: "qm9_reduced_100.xyz" # file where the positions are stored
+targets:
+  energy:
+    key: "U0" # name of the target value

--- a/examples/basic_usage/eval.yaml
+++ b/examples/basic_usage/eval.yaml
@@ -1,0 +1,1 @@
+../../docs/static/qm9/eval.yaml

--- a/examples/basic_usage/usage.sh
+++ b/examples/basic_usage/usage.sh
@@ -8,12 +8,12 @@ metatensor-models train options.yaml
 metatensor-models train --help
 
 # We now evaluate the model on the training dataset, where the first arguments specifies
-# the model and the second the structure file
+# trained model and the second an option file containing the dataset for evaulation.
 
-metatensor-models eval model.pt qm9_reduced_100.xyz
+metatensor-models eval model.pt eval.yaml
 
-# The evaluation command predicts the property the model was trained against; here "U0".
-# The predictions together with the structures have been written in a file named
+# The evaluation command predicts those properties the model was trained against; here
+# "U0". The predictions together with the structures have been written in a file named
 # ``output.xyz`` in the current directory. The written file starts with the following
 # lines
 

--- a/examples/basic_usage/usage.sh
+++ b/examples/basic_usage/usage.sh
@@ -8,7 +8,7 @@ metatensor-models train options.yaml
 metatensor-models train --help
 
 # We now evaluate the model on the training dataset, where the first arguments specifies
-# trained model and the second an option file containing the dataset for evaulation.
+# trained model and the second an option file containing the path of the dataset for evaulation.
 
 metatensor-models eval model.pt eval.yaml
 

--- a/src/metatensor/models/cli/eval_model.py
+++ b/src/metatensor/models/cli/eval_model.py
@@ -135,8 +135,8 @@ def eval_model(
     """Evaluate a pretrained model on a given data set.
 
     If ``options`` contains a ``targets`` sub-section, RMSE values will be reported. If
-    this sub-section is missing, only a xyz-file with containing the properties the model
-    was trained against is written.
+    this sub-section is missing, only a xyz-file with containing the properties the
+    model was trained against is written.
 
     :param model: Saved model to be evaluated.
     :param options: DictConfig to define a test dataset taken for the evaluation.

--- a/src/metatensor/models/cli/eval_model.py
+++ b/src/metatensor/models/cli/eval_model.py
@@ -132,10 +132,10 @@ def _eval_targets(model, dataset: Union[Dataset, torch.utils.data.Subset]) -> No
 def eval_model(
     model: torch.nn.Module, options: DictConfig, output: str = "output.xyz"
 ) -> None:
-    """Evaluate a pretrained model on a certain data set.
+    """Evaluate a pretrained model on a given data set.
 
     If ``options`` contains a ``targets`` sub-section, RMSE values will be reported. If
-    this sub-section is missing only a xyz-file with containing the properties the model
+    this sub-section is missing, only a xyz-file with containing the properties the model
     was trained against is written.
 
     :param model: Saved model to be evaluated.

--- a/src/metatensor/models/cli/eval_model.py
+++ b/src/metatensor/models/cli/eval_model.py
@@ -3,7 +3,7 @@ import logging
 from typing import Dict, Tuple, Union
 
 import torch
-from omegaconf import OmegaConf
+from omegaconf import DictConfig, OmegaConf
 
 from ..utils.compute_loss import compute_model_loss
 from ..utils.data import (
@@ -13,18 +13,15 @@ from ..utils.data import (
     read_targets,
     write_predictions,
 )
-from ..utils.data.dataset import _train_test_random_split
 from ..utils.extract_targets import get_outputs_dict
 from ..utils.info import finalize_aggregated_info, update_aggregated_info
 from ..utils.loss import TensorMapDictLoss
 from ..utils.model_io import load_model
-from ..utils.omegaconf import _has_yaml_suffix, check_units, expand_dataset_config
+from ..utils.omegaconf import expand_dataset_config
 from .formatter import CustomHelpFormatter
 
 
 logger = logging.getLogger(__name__)
-
-CHOICES_EVAL_ON = ["train", "validation", "test"]
 
 
 def _add_eval_model_parser(subparser: argparse._SubParsersAction) -> None:
@@ -42,20 +39,14 @@ def _add_eval_model_parser(subparser: argparse._SubParsersAction) -> None:
     )
     parser.set_defaults(callable="eval_model")
     parser.add_argument(
-        "options",
-        type=_has_yaml_suffix,
-        help="Options file to define a test dataset taken for the evaluation.",
-    )
-    parser.add_argument(
         "model",
-        type=str,
-        help="saved model to be evaluated",
+        type=load_model,
+        help="Saved model to be evaluated.",
     )
     parser.add_argument(
-        "eval_on",
-        type=str,
-        choices=CHOICES_EVAL_ON,
-        help="On which part of the dataset should the model be evaluated.",
+        "options",
+        type=OmegaConf.load,
+        help="Eval options file to define a dataset for evaluation.",
     )
     parser.add_argument(
         "-o",
@@ -139,77 +130,32 @@ def _eval_targets(model, dataset: Union[Dataset, torch.utils.data.Subset]) -> No
 
 
 def eval_model(
-    options: str, model: str, eval_on: str = "test", output: str = "output.xyz"
+    model: torch.nn.Module, options: DictConfig, output: str = "output.xyz"
 ) -> None:
-    """Evaluate a pretrained model on a set.
+    """Evaluate a pretrained model on a certain data set.
 
-    The test dataset will be selected as defined in the options yaml file. Predicted
-    values will be written ``output``.
+    If ``options`` contains a ``targets`` sub-section, RMSE values will be reported. If
+    this sub-section is missing only a xyz-file with containing the properties the model
+    was trained against is written.
 
-    :param options: Options file path to define a test dataset taken for the evaluation.
-    :param model: Path to a saved model
-    :param eval_on: On which part of the dataset should the model be evaluated. Possible
-        values are 'test', 'train' or 'validation'.
+    :param model: Saved model to be evaluated.
+    :param options: DictConfig to define a test dataset taken for the evaluation.
     :param output: Path to save the predicted values
     """
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logger.info("Setting up evaluation set.")
 
-    conf = OmegaConf.load(options)
-
-    if eval_on not in CHOICES_EVAL_ON:
-        raise ValueError(
-            f"{eval_on!r} is not a possible choice for `eval_on`. Choose from: "
-            f"{','.join(CHOICES_EVAL_ON)}"
-        )
-
-    logger.info("Setting up {eval_on} set")
-    train_options = conf["test_set"]
-    eval_options = conf["{eval_on}_set"]
-
-    loaded_model = load_model(model)
-
+    options = expand_dataset_config(options)
     eval_structures = read_structures(
-        filename=eval_options["structures"]["read_from"],
-        fileformat=eval_options["structures"]["file_format"],
+        filename=options["structures"]["read_from"],
+        fileformat=options["structures"]["file_format"],
     )
-
     # Predict targets
-    if hasattr(eval_options, "targets"):
-        if isinstance(eval_options, float):
-            eval_size = eval_options
-            train_size = 1 - eval_size
+    if hasattr(options, "targets"):
+        eval_targets = read_targets(options["targets"])
+        eval_dataset = Dataset(eval_structures, eval_targets)
+        _eval_targets(model, eval_dataset)
 
-            if eval_size < 0 or eval_size >= 1:
-                raise ValueError(f"{eval_on} set split must be between 0 and 1.")
-
-            train_structures = read_structures(
-                filename=train_options["structures"]["read_from"],
-                fileformat=train_options["structures"]["file_format"],
-            )
-            train_targets = read_targets(train_options["targets"])
-            train_dataset = Dataset(train_structures, train_targets)
-
-            generator = torch.Generator()
-            if conf["seed"] is not None:
-                generator.manual_seed(conf["seed"])
-
-            _, eval_dataset = _train_test_random_split(
-                train_dataset=train_dataset,
-                train_size=train_size,
-                test_size=eval_size,
-                generator=generator,
-            )
-
-            # Select eval_structures based on fraction
-            eval_structures = [eval_structures[index] for index in eval_dataset.indices]
-
-        else:
-            eval_options = expand_dataset_config(eval_options)
-            eval_targets = read_targets(eval_options["targets"])
-            eval_dataset = Dataset(eval_structures, eval_targets)
-            check_units(actual_options=eval_options, desired_options=train_options)
-
-        _eval_targets(loaded_model, eval_dataset)
-
-    # Predict strcutures
-    predictions = loaded_model(eval_structures, loaded_model.capabilities.outputs)
+    # Predict structures
+    predictions = model(eval_structures, model.capabilities.outputs)
     write_predictions(output, predictions, eval_structures)

--- a/src/metatensor/models/cli/train_model.py
+++ b/src/metatensor/models/cli/train_model.py
@@ -19,7 +19,7 @@ from .. import CONFIG_PATH
 from ..utils.data import Dataset, get_all_species, read_structures, read_targets
 from ..utils.data.dataset import _train_test_random_split
 from ..utils.model_io import save_model
-from ..utils.omegaconf import _has_yaml_suffix, check_units, expand_dataset_config
+from ..utils.omegaconf import check_units, expand_dataset_config
 from .eval_model import _eval_targets
 from .formatter import CustomHelpFormatter
 
@@ -182,7 +182,6 @@ def _train_model_hydra(options: DictConfig) -> None:
     logger.info("Setting up test set")
     test_options = options["test_set"]
 
-    # Always split test datset before validation to ensure same split as in eval script!
     if isinstance(test_options, float):
         test_size = test_options
         train_size -= test_size

--- a/src/metatensor/models/cli/train_model.py
+++ b/src/metatensor/models/cli/train_model.py
@@ -19,7 +19,7 @@ from .. import CONFIG_PATH
 from ..utils.data import Dataset, get_all_species, read_structures, read_targets
 from ..utils.data.dataset import _train_test_random_split
 from ..utils.model_io import save_model
-from ..utils.omegaconf import check_units, expand_dataset_config, _has_yaml_suffix
+from ..utils.omegaconf import _has_yaml_suffix, check_units, expand_dataset_config
 from .eval_model import _eval_targets
 from .formatter import CustomHelpFormatter
 

--- a/src/metatensor/models/soap_bpnn/train.py
+++ b/src/metatensor/models/soap_bpnn/train.py
@@ -2,7 +2,6 @@ import logging
 import warnings
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
-from ..utils.extract_targets import get_outputs_dict
 
 import rascaline
 import torch
@@ -17,6 +16,7 @@ from ..utils.data import (
     combine_dataloaders,
     get_all_targets,
 )
+from ..utils.extract_targets import get_outputs_dict
 from ..utils.info import finalize_aggregated_info, update_aggregated_info
 from ..utils.logging import MetricLogger
 from ..utils.loss import TensorMapDictLoss
@@ -151,7 +151,7 @@ def train(
     validation_dataloader = combine_dataloaders(validation_dataloaders, shuffle=False)
 
     # Extract all the possible outputs and their gradients from the training set:
-    outputs_dict = _get_outputs_dict(train_datasets)
+    outputs_dict = get_outputs_dict(train_datasets)
     for output_name in outputs_dict.keys():
         if output_name not in model_capabilities.outputs:
             raise ValueError(

--- a/src/metatensor/models/soap_bpnn/train.py
+++ b/src/metatensor/models/soap_bpnn/train.py
@@ -2,6 +2,7 @@ import logging
 import warnings
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
+from ..utils.extract_targets import get_outputs_dict
 
 import rascaline
 import torch
@@ -243,27 +244,3 @@ def train(
                 break
 
     return model
-
-
-def _get_outputs_dict(datasets: List[Union[Dataset, torch.utils.data.Subset]]):
-    """
-    This is a helper function that extracts all the possible outputs and their gradients
-    from a list of datasets.
-
-    :param datasets: A list of Datasets or Subsets.
-
-    :returns: A dictionary mapping output names to a list of "values" (always)
-        and possible gradients.
-    """
-
-    outputs_dict = {}
-    for dataset in datasets:
-        sample_batch = next(iter(dataset))
-        targets = sample_batch[1]  # this is a dictionary of TensorMaps
-        for target_name, target_tmap in targets.items():
-            if target_name not in outputs_dict:
-                outputs_dict[target_name] = [
-                    "values"
-                ] + target_tmap.block().gradients_list()
-
-    return outputs_dict

--- a/src/metatensor/models/utils/data/dataset.py
+++ b/src/metatensor/models/utils/data/dataset.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import logging
 import os
 from typing import Dict, List, Tuple
@@ -7,6 +8,10 @@ import numpy as np
 import torch
 from metatensor.torch import Labels, TensorMap
 from metatensor.torch.atomistic import ModelCapabilities, System
+from torch import Generator, default_generator
+from torch.utils.data import Subset, random_split
+
+from torch.utils.data import random_split
 
 
 logger = logging.getLogger(__name__)
@@ -231,3 +236,19 @@ def check_datasets(
                 "a result of a random train/validation split. You can "
                 "avoid this by providing a validation dataset manually."
             )
+
+
+def _train_test_random_split(
+    train_dataset: Dataset,
+    train_size: float,
+    test_size: float,
+    generator: Optional[Generator] = default_generator,
+) -> List[Subset]:
+    if train_size <= 0:
+        raise ValueError("Fraction of the train set is smaller or equal to 0!")
+
+    # normalize fractions
+    lengths = torch.tensor([train_size, test_size])
+    lengths /= lengths.sum()
+
+    return random_split(dataset=train_dataset, lengths=lengths, generator=generator)

--- a/src/metatensor/models/utils/data/dataset.py
+++ b/src/metatensor/models/utils/data/dataset.py
@@ -1,7 +1,6 @@
-from typing import Optional
 import logging
 import os
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import metatensor.torch
 import numpy as np
@@ -10,8 +9,6 @@ from metatensor.torch import Labels, TensorMap
 from metatensor.torch.atomistic import ModelCapabilities, System
 from torch import Generator, default_generator
 from torch.utils.data import Subset, random_split
-
-from torch.utils.data import random_split
 
 
 logger = logging.getLogger(__name__)

--- a/src/metatensor/models/utils/extract_targets.py
+++ b/src/metatensor/models/utils/extract_targets.py
@@ -1,0 +1,27 @@
+from typing import List, Union
+import torch
+from .data import Dataset
+
+
+def get_outputs_dict(datasets: List[Union[Dataset, torch.utils.data.Subset]]):
+    """
+    This is a helper function that extracts all the possible outputs and their gradients
+    from a list of datasets.
+
+    :param datasets: A list of Datasets or Subsets.
+
+    :returns: A dictionary mapping output names to a list of "values" (always)
+        and possible gradients.
+    """
+
+    outputs_dict = {}
+    for dataset in datasets:
+        sample_batch = next(iter(dataset))
+        targets = sample_batch[1]  # this is a dictionary of TensorMaps
+        for target_name, target_tmap in targets.items():
+            if target_name not in outputs_dict:
+                outputs_dict[target_name] = [
+                    "values"
+                ] + target_tmap.block().gradients_list()
+
+    return outputs_dict

--- a/src/metatensor/models/utils/extract_targets.py
+++ b/src/metatensor/models/utils/extract_targets.py
@@ -1,5 +1,7 @@
 from typing import List, Union
+
 import torch
+
 from .data import Dataset
 
 

--- a/src/metatensor/models/utils/omegaconf.py
+++ b/src/metatensor/models/utils/omegaconf.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Union
 
 from omegaconf import DictConfig, OmegaConf
+import argparse
 
 
 def file_format(_parent_):
@@ -21,6 +22,15 @@ def _resolve_single_str(config):
         return OmegaConf.create({"read_from": config})
     else:
         return config
+
+
+def _has_yaml_suffix(s: str) -> str:
+    """Checks if a string has a .yaml suffix."""
+
+    if Path(s).suffix != ".yaml":
+        raise argparse.ArgumentTypeError(f"Options file '{s}' must be a `.yaml` file.")
+
+    return s
 
 
 # BASE CONFIGURATIONS

--- a/src/metatensor/models/utils/omegaconf.py
+++ b/src/metatensor/models/utils/omegaconf.py
@@ -1,8 +1,8 @@
+import argparse
 from pathlib import Path
 from typing import Union
 
 from omegaconf import DictConfig, OmegaConf
-import argparse
 
 
 def file_format(_parent_):

--- a/src/metatensor/models/utils/omegaconf.py
+++ b/src/metatensor/models/utils/omegaconf.py
@@ -1,4 +1,3 @@
-import argparse
 from pathlib import Path
 from typing import Union
 
@@ -22,15 +21,6 @@ def _resolve_single_str(config):
         return OmegaConf.create({"read_from": config})
     else:
         return config
-
-
-def _has_yaml_suffix(s: str) -> str:
-    """Checks if a string has a .yaml suffix."""
-
-    if Path(s).suffix != ".yaml":
-        raise argparse.ArgumentTypeError(f"Options file '{s}' must be a `.yaml` file.")
-
-    return s
 
 
 # BASE CONFIGURATIONS

--- a/src/metatensor/models/utils/omegaconf.py
+++ b/src/metatensor/models/utils/omegaconf.py
@@ -103,65 +103,68 @@ def expand_dataset_config(conf: Union[str, DictConfig]) -> DictConfig:
             {"structures": read_from, "targets": {"energy": read_from}}
         )
 
-    if type(conf["structures"]) is str:
-        conf["structures"] = _resolve_single_str(conf["structures"])
+    if hasattr(conf, "structures"):
+        if type(conf["structures"]) is str:
+            conf["structures"] = _resolve_single_str(conf["structures"])
 
-    conf["structures"] = OmegaConf.merge(CONF_STRUCTURES, conf["structures"])
+        conf["structures"] = OmegaConf.merge(CONF_STRUCTURES, conf["structures"])
 
-    for target_key, target in conf["targets"].items():
-        if type(target) is str:
-            target = _resolve_single_str(target)
+    if hasattr(conf, "targets"):
+        for target_key, target in conf["targets"].items():
+            if type(target) is str:
+                target = _resolve_single_str(target)
 
-        # Add default gradients "energy" target section
-        if target_key == "energy":
-            # For special case of the "energy" we add the section for force and stress
-            # gradient by default
-            target = OmegaConf.merge(CONF_ENERGY, target)
-        else:
-            target = OmegaConf.merge(CONF_TARGET, target)
+            # Add default gradients "energy" target section
+            if target_key == "energy":
+                # For special case of the "energy" we add the section for force and
+                # stress gradient by default
+                target = OmegaConf.merge(CONF_ENERGY, target)
+            else:
+                target = OmegaConf.merge(CONF_TARGET, target)
 
-        if target["key"] is None:
-            target["key"] = target_key
+            if target["key"] is None:
+                target["key"] = target_key
 
-        # Update DictConfig to allow for config node interpolation
-        conf["targets"][target_key] = target
+            # Update DictConfig to allow for config node interpolation
+            conf["targets"][target_key] = target
 
-        # merge and interpolate possibly present gradients with default gradient config
-        for gradient_key, gradient_conf in conf["targets"][target_key].items():
-            if gradient_key in KNWON_GRADIENTS:
-                if gradient_conf is True:
-                    gradient_conf = CONF_GRADIENT.copy()
-                elif type(gradient_conf) is str:
-                    gradient_conf = _resolve_single_str(gradient_conf)
+            # merge and interpolate possibly present gradients with default gradient
+            # config
+            for gradient_key, gradient_conf in conf["targets"][target_key].items():
+                if gradient_key in KNWON_GRADIENTS:
+                    if gradient_conf is True:
+                        gradient_conf = CONF_GRADIENT.copy()
+                    elif type(gradient_conf) is str:
+                        gradient_conf = _resolve_single_str(gradient_conf)
 
-                if isinstance(gradient_conf, DictConfig):
-                    gradient_conf = OmegaConf.merge(CONF_GRADIENT, gradient_conf)
+                    if isinstance(gradient_conf, DictConfig):
+                        gradient_conf = OmegaConf.merge(CONF_GRADIENT, gradient_conf)
 
-                    if gradient_conf["key"] is None:
-                        gradient_conf["key"] = gradient_key
+                        if gradient_conf["key"] is None:
+                            gradient_conf["key"] = gradient_key
 
-                    conf["targets"][target_key][gradient_key] = gradient_conf
+                        conf["targets"][target_key][gradient_key] = gradient_conf
 
-        # If user sets the virial gradient and leaves the stress section untouched,
-        # we disable the by default enabled stress gradient section.
-        base_stress_gradient_conf = CONF_GRADIENT.copy()
-        base_stress_gradient_conf["key"] = "stress"
+            # If user sets the virial gradient and leaves the stress section untouched,
+            # we disable the by default enabled stress gradient section.
+            base_stress_gradient_conf = CONF_GRADIENT.copy()
+            base_stress_gradient_conf["key"] = "stress"
 
-        if (
-            target_key == "energy"
-            and conf["targets"][target_key]["virial"]
-            and conf["targets"][target_key]["stress"] == base_stress_gradient_conf
-        ):
-            conf["targets"][target_key]["stress"] = False
+            if (
+                target_key == "energy"
+                and conf["targets"][target_key]["virial"]
+                and conf["targets"][target_key]["stress"] == base_stress_gradient_conf
+            ):
+                conf["targets"][target_key]["stress"] = False
 
-        if (
-            conf["targets"][target_key]["stress"]
-            and conf["targets"][target_key]["virial"]
-        ):
-            raise ValueError(
-                f"Cannot perform training with respect to virials and stress as in "
-                f"section {target_key}. Set either `virials: off` or `stress: off`."
-            )
+            if (
+                conf["targets"][target_key]["stress"]
+                and conf["targets"][target_key]["virial"]
+            ):
+                raise ValueError(
+                    f"Cannot perform training with respect to virials and stress as in "
+                    f"section {target_key}. Set either `virials: off` or `stress: off`."
+                )
 
     return conf
 

--- a/tests/cli/test_eval_model.py
+++ b/tests/cli/test_eval_model.py
@@ -1,29 +1,79 @@
+import logging
 import shutil
 import subprocess
 from pathlib import Path
 
 import ase.io
 import pytest
+from omegaconf import OmegaConf
+
+from metatensor.models.cli import eval_model
+from metatensor.models.utils.model_io import load_model
 
 
 RESOURCES_PATH = Path(__file__).parent.resolve() / ".." / "resources"
+MODEL_PATH = RESOURCES_PATH / "bpnn-model.pt"
+OPTIONS_PATH = RESOURCES_PATH / "eval.yaml"
 
 
-@pytest.mark.parametrize("output", [None, "foo.xyz"])
-def test_eval(output, monkeypatch, tmp_path):
-    """Test that training via the training cli runs without an error raise."""
+@pytest.fixture
+def model():
+    return load_model(MODEL_PATH)
+
+
+@pytest.fixture
+def options():
+    return OmegaConf.load(OPTIONS_PATH)
+
+
+def test_eval_cli(monkeypatch, tmp_path):
+    """Test succesful run of the eval script via the CLI with default arguments"""
     monkeypatch.chdir(tmp_path)
     shutil.copy(RESOURCES_PATH / "qm9_reduced_100.xyz", "qm9_reduced_100.xyz")
-    shutil.copy(RESOURCES_PATH / "bpnn-model.pt", "bpnn-model.pt")
 
-    command = ["metatensor-models", "eval", "bpnn-model.pt", "qm9_reduced_100.xyz"]
-
-    if output is not None:
-        command += ["-o", output]
-    else:
-        output = "output.xyz"
+    command = [
+        "metatensor-models",
+        "eval",
+        str(MODEL_PATH),
+        str(OPTIONS_PATH),
+    ]
 
     subprocess.check_call(command)
 
-    frames = ase.io.read(output, ":")
+    assert Path("output.xyz").is_file()
+
+
+def test_eval(monkeypatch, tmp_path, caplog, model, options):
+    """Test that eval via python API runs without an error raise."""
+    monkeypatch.chdir(tmp_path)
+    caplog.set_level(logging.INFO)
+
+    shutil.copy(RESOURCES_PATH / "qm9_reduced_100.xyz", "qm9_reduced_100.xyz")
+
+    eval_model(
+        model=model,
+        options=options,
+        output="foo.xyz",
+    )
+
+    # Test target predictions
+    assert "energy RMSE" in "".join([rec.message for rec in caplog.records])
+
+    # Test file is written predictions
+    frames = ase.io.read("foo.xyz", ":")
     frames[0].info["energy"]
+
+
+def test_eval_no_targets(monkeypatch, tmp_path, model, options):
+    monkeypatch.chdir(tmp_path)
+
+    shutil.copy(RESOURCES_PATH / "qm9_reduced_100.xyz", "qm9_reduced_100.xyz")
+
+    options.pop("targets")
+
+    eval_model(
+        model=model,
+        options=options,
+    )
+
+    assert Path("output.xyz").is_file()

--- a/tests/resources/eval.yaml
+++ b/tests/resources/eval.yaml
@@ -1,0 +1,1 @@
+../../docs/static/qm9/eval.yaml

--- a/tests/utils/test_omegaconf.py
+++ b/tests/utils/test_omegaconf.py
@@ -249,3 +249,19 @@ def test_check_units():
         ),
     ):
         check_units(actual_options=test_options3, desired_options=train_options)
+
+
+def test_missing_targets_section():
+    conf = {"structures": "foo.xyz"}
+    conf_expanded = expand_dataset_config(OmegaConf.create(conf))
+
+    assert conf_expanded["structures"]["read_from"] == "foo.xyz"
+    assert conf_expanded["structures"]["file_format"] == ".xyz"
+
+
+def test_missing_strcutures_section():
+    conf = {"targets": {"energies": "foo.xyz"}}
+    conf_expanded = expand_dataset_config(OmegaConf.create(conf))
+
+    assert conf_expanded["targets"]["energies"]["read_from"] == "foo.xyz"
+    assert conf_expanded["targets"]["energies"]["file_format"] == ".xyz"


### PR DESCRIPTION
the eval function will now take an `options.yaml` as the train function to evaluate the RMSE if such data is available. The user can also just removes the `targets` if he doesn't have target data. Then we only predict and write a file without prompting the RMSE values.

the internal functions of eval will now also be used to report the test, train and validation rmse at the end of the training.

# TODO

- [x] finish implementation of actual target evaluation
- [x] Add documentation 
- [x] Write tests* 


* Especially that the test splits are the same between `train` and `eval`.