### PR TITLE
More Pythonic API for train and export

### DIFF
--- a/src/metatensor/models/cli/export_model.py
+++ b/src/metatensor/models/cli/export_model.py
@@ -1,6 +1,7 @@
 import argparse
 import warnings
 
+import torch
 from metatensor.torch.atomistic import MetatensorAtomisticModel
 
 from ..utils.model_io import load_model
@@ -22,7 +23,7 @@ def _add_export_model_parser(subparser: argparse._SubParsersAction) -> None:
 
     parser.add_argument(
         "model",
-        type=str,
+        type=load_model,
         help="Saved model which should be exported",
     )
     parser.add_argument(
@@ -36,16 +37,14 @@ def _add_export_model_parser(subparser: argparse._SubParsersAction) -> None:
     )
 
 
-def export_model(model: str, output: str) -> None:
+def export_model(model: torch.nn.Module, output: str) -> None:
     """Export a pre-trained model to run MD simulations
 
     :param model: Path to a saved model
     :param output: Path to save the exported model
     """
 
-    loaded_model = load_model(model)
-
-    for model_output_name, model_output in loaded_model.capabilities.outputs.items():
+    for model_output_name, model_output in model.capabilities.outputs.items():
         if model_output.unit == "":
             warnings.warn(
                 f"No units were provided for the `{model_output_name}` output. "
@@ -53,5 +52,5 @@ def export_model(model: str, output: str) -> None:
                 stacklevel=1,
             )
 
-    wrapper = MetatensorAtomisticModel(loaded_model.eval(), loaded_model.capabilities)
+    wrapper = MetatensorAtomisticModel(model.eval(), model.capabilities)
     wrapper.export(output)

--- a/src/metatensor/models/utils/data/writers/__init__.py
+++ b/src/metatensor/models/utils/data/writers/__init__.py
@@ -22,7 +22,7 @@ def write_predictions(
     For certain file suffixes also the structures will be written (i.e ``xyz``).
 
     :param filename: name of the file to write
-    :param predictions: :py:class:`metatensor.torch.TensorMap` containinb the
+    :param predictions: :py:class:`metatensor.torch.TensorMap` containing the
         predictions that should be written
     :param structures: list of structures that for some writers will also be written
     :param fileformat: format of the target value file. If :py:obj:`None` the format is

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -8,17 +8,28 @@ import metatensor.torch  # noqa
 import pytest
 import torch
 from omegaconf import OmegaConf
+from omegaconf.errors import ConfigKeyError
+
+from metatensor.models.cli import train_model
 
 
 RESOURCES_PATH = Path(__file__).parent.resolve() / ".." / "resources"
+DATASET_PATH = RESOURCES_PATH / "qm9_reduced_100.xyz"
+OPTIONS_PATH = RESOURCES_PATH / "options.yaml"
+MODEL_PATH = RESOURCES_PATH / "bpnn-model.pt"
+
+
+@pytest.fixture
+def options():
+    return OmegaConf.load(OPTIONS_PATH)
 
 
 @pytest.mark.parametrize("output", [None, "mymodel.pt"])
 def test_train(monkeypatch, tmp_path, output):
     """Test that training via the training cli runs without an error raise."""
     monkeypatch.chdir(tmp_path)
-    shutil.copy(RESOURCES_PATH / "qm9_reduced_100.xyz", "qm9_reduced_100.xyz")
-    shutil.copy(RESOURCES_PATH / "options.yaml", "options.yaml")
+    shutil.copy(DATASET_PATH, "qm9_reduced_100.xyz")
+    shutil.copy(OPTIONS_PATH, "options.yaml")
 
     command = ["metatensor-models", "train", "options.yaml"]
 
@@ -51,16 +62,14 @@ def test_train(monkeypatch, tmp_path, output):
 
 @pytest.mark.parametrize("test_set_file", (True, False))
 @pytest.mark.parametrize("validation_set_file", (True, False))
-@pytest.mark.parametrize("output", [None, "mymodel.pt"])
 def test_train_explicit_validation_test(
-    monkeypatch, tmp_path, test_set_file, validation_set_file, output
+    monkeypatch, tmp_path, test_set_file, validation_set_file, options
 ):
     """Test that training via the training cli runs without an error raise
     also when the validation and test sets are provided explicitly."""
     monkeypatch.chdir(tmp_path)
 
-    structures = ase.io.read(RESOURCES_PATH / "qm9_reduced_100.xyz", ":")
-    options = OmegaConf.load(RESOURCES_PATH / "options.yaml")
+    structures = ase.io.read(DATASET_PATH, ":")
 
     ase.io.write("qm9_reduced_100.xyz", structures[:50])
 
@@ -74,52 +83,29 @@ def test_train_explicit_validation_test(
         options["test_set"] = options["training_set"].copy()
         options["test_set"]["structures"]["read_from"] = "validation.xyz"
 
-    OmegaConf.save(config=options, f="options.yaml")
-    command = ["metatensor-models", "train", "options.yaml"]
+    train_model(options)
 
-    if output is not None:
-        command += ["-o", output]
-    else:
-        output = "model.pt"
-
-    subprocess.check_call(command)
-    assert Path(output).is_file()
+    assert Path("model.pt").is_file()
 
 
-def test_continue(monkeypatch, tmp_path):
+def test_continue(options, monkeypatch, tmp_path):
     """Test that continuing training from a checkpoint runs without an error raise."""
     monkeypatch.chdir(tmp_path)
-    shutil.copy(RESOURCES_PATH / "qm9_reduced_100.xyz", "qm9_reduced_100.xyz")
-    shutil.copy(RESOURCES_PATH / "bpnn-model.pt", "bpnn-model.pt")
-    shutil.copy(RESOURCES_PATH / "options.yaml", "options.yaml")
+    shutil.copy(DATASET_PATH, "qm9_reduced_100.xyz")
 
-    command = ["metatensor-models", "train", "options.yaml", "-c bpnn-model.pt"]
-    subprocess.check_call(command)
+    train_model(options, continue_from=MODEL_PATH)
 
 
-def test_continue_different_dataset(monkeypatch, tmp_path):
+def test_continue_different_dataset(options, monkeypatch, tmp_path):
     """Test that continuing training from a checkpoint runs without an error raise
     with a different dataset than the original."""
     monkeypatch.chdir(tmp_path)
     shutil.copy(RESOURCES_PATH / "ethanol_reduced_100.xyz", "ethanol_reduced_100.xyz")
-    shutil.copy(
-        RESOURCES_PATH / "bpnn-model.pt",
-        "bpnn-model.pt",
-    )
 
-    options = OmegaConf.load(RESOURCES_PATH / "options.yaml")
     options["training_set"]["structures"]["read_from"] = "ethanol_reduced_100.xyz"
     options["training_set"]["targets"]["energy"]["key"] = "energy"
-    print(options)
-    OmegaConf.save(config=options, f="options.yaml")
 
-    command = [
-        "metatensor-models",
-        "train",
-        "options.yaml",
-        "-c bpnn-model.pt",
-    ]
-    subprocess.check_call(command)
+    train_model(options, continue_from=MODEL_PATH)
 
 
 def test_hydra_arguments():
@@ -132,91 +118,61 @@ def test_hydra_arguments():
     assert "num_epochs: 1" in str(out)
 
 
-def test_no_architecture_name(monkeypatch, tmp_path):
+def test_no_architecture_name(options):
     """Test error raise if architecture.name is not set."""
-    monkeypatch.chdir(tmp_path)
-
-    options = OmegaConf.load(RESOURCES_PATH / "options.yaml")
     options["architecture"].pop("name")
-    OmegaConf.save(config=options, f="options.yaml")
 
-    try:
-        subprocess.check_output(
-            ["metatensor-models", "train", "options.yaml"], stderr=subprocess.STDOUT
-        )
-    except subprocess.CalledProcessError as captured:
-        assert "Architecture name is not defined!" in str(captured.output)
+    with pytest.raises(ConfigKeyError, match="Architecture name is not defined!"):
+        train_model(options)
 
 
 @pytest.mark.parametrize("seed", [1234, None, 0, -123])
 @pytest.mark.parametrize("architecture_name", ["soap_bpnn"])
-def test_model_consistency_with_seed(monkeypatch, tmp_path, architecture_name, seed):
+def test_model_consistency_with_seed(
+    options, monkeypatch, tmp_path, architecture_name, seed, capsys
+):
     """Checks final model consistency with a fixed seed."""
     monkeypatch.chdir(tmp_path)
-    shutil.copy(RESOURCES_PATH / "qm9_reduced_100.xyz", "qm9_reduced_100.xyz")
+    shutil.copy(DATASET_PATH, "qm9_reduced_100.xyz")
 
-    options = OmegaConf.load(RESOURCES_PATH / "options.yaml")
     options["architecture"]["name"] = architecture_name
     options["seed"] = seed
-    OmegaConf.save(config=options, f="options.yaml")
 
-    if seed is not None:
-        if seed < 0:
-            try:
-                subprocess.check_output(
-                    ["metatensor-models", "train", "options.yaml", "-o", "model1.pt"],
-                    stderr=subprocess.STDOUT,
-                )
-            except subprocess.CalledProcessError as captured:
-                assert "should be a positive number or None." in str(captured.output)
+    if seed is not None and seed < 0:
+        with pytest.raises(SystemExit):
+            train_model(options)
+            captured = capsys.readouterr()
+            assert "should be a positive number or None." in captured.out
+        return
+
+    train_model(options, output="model1.pt")
+    train_model(options, output="model2.pt")
+
+    m1 = torch.load("model1.pt")
+    m2 = torch.load("model2.pt")
+
+    for index, i in enumerate(m1["model_state_dict"]):
+        tensor1 = m1["model_state_dict"][i]
+        tensor2 = m2["model_state_dict"][i]
+
+        # The first tensor only depend on the chemical compositions (not on the
+        # seed) and should alwyas be the same.
+        if index == 0:
+            assert torch.allclose(tensor1, tensor2)
         else:
-            subprocess.check_call(
-                ["metatensor-models", "train", "options.yaml", "-o", "model1.pt"]
-            )
-            subprocess.check_call(
-                ["metatensor-models", "train", "options.yaml", "-o", "model2.pt"]
-            )
-
-            m1 = torch.load("model1.pt")
-            m2 = torch.load("model2.pt")
-
-            for i in m1["model_state_dict"]:
-                tensor1 = m1["model_state_dict"][i]
-                tensor2 = m2["model_state_dict"][i]
-                assert torch.allclose(tensor1, tensor2)
-    else:
-        subprocess.check_call(
-            ["metatensor-models", "train", "options.yaml", "-o", "model1.pt"]
-        )
-        subprocess.check_call(
-            ["metatensor-models", "train", "options.yaml", "-o", "model2.pt"]
-        )
-
-        m1 = torch.load("model1.pt")
-        m2 = torch.load("model2.pt")
-
-        for index, i in enumerate(m1["model_state_dict"]):
-            tensor1 = m1["model_state_dict"][i]
-            tensor2 = m2["model_state_dict"][i]
-            if index == 0:
-                # The first tensor only depend on the chemical compositions (not on the
-                # seed) and should alwyas be the same.
-                assert torch.allclose(tensor1, tensor2)
-            else:
+            if seed is None:
                 assert not torch.allclose(tensor1, tensor2)
+            else:
+                assert torch.allclose(tensor1, tensor2)
 
 
-def test_error_base_precision(monkeypatch, tmp_path):
+def test_error_base_precision(options, monkeypatch, tmp_path, capsys):
     """Test unsupported `base_precision`"""
     monkeypatch.chdir(tmp_path)
 
-    options = OmegaConf.load(RESOURCES_PATH / "options.yaml")
     options["base_precision"] = "123"
-    OmegaConf.save(config=options, f="options.yaml")
 
-    try:
-        subprocess.check_output(
-            ["metatensor-models", "train", "options.yaml"], stderr=subprocess.STDOUT
-        )
-    except subprocess.CalledProcessError as captured:
-        assert "Only 64, 32 or 16 are possible values for " in str(captured.output)
+    with pytest.raises(SystemExit):
+        train_model(options)
+        captured = capsys.readouterr()
+        assert "Only 64, 32 or 16 are possible values for" in captured.out

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -122,18 +122,6 @@ def test_continue_different_dataset(monkeypatch, tmp_path):
     subprocess.check_call(command)
 
 
-def test_yml_error():
-    """Test error raise of the option file is not a .yaml file."""
-    try:
-        subprocess.check_output(
-            ["metatensor-models", "train", "options.yml"], stderr=subprocess.STDOUT
-        )
-    except subprocess.CalledProcessError as captured:
-        assert "Options file 'options.yml' must be a `.yaml` file." in str(
-            captured.output
-        )
-
-
 def test_hydra_arguments():
     """Test if hydra arguments work."""
     option_path = str(RESOURCES_PATH / "options.yaml")


### PR DESCRIPTION
I am abusing argparse's `type` field to provide more python like parameters to `train` and `export` instead only strings. This might also simplify adding new tests because you don't always have to start a new shell for doing a test.

`eval` is left out because there is currently a bigger rewrite #65 .

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--67.org.readthedocs.build/en/67/

<!-- readthedocs-preview metatensor-models end -->