### PR TITLE
Added tests for model loading

### DIFF
--- a/src/metatensor/models/cli/eval_model.py
+++ b/src/metatensor/models/cli/eval_model.py
@@ -10,7 +10,6 @@ from omegaconf import DictConfig, OmegaConf
 from ..utils.compute_loss import compute_model_loss
 from ..utils.data import collate_fn, read_structures, read_targets, write_predictions
 from ..utils.errors import ArchitectureError
-from ..utils.export import is_exported
 from ..utils.extract_targets import get_outputs_dict
 from ..utils.info import finalize_aggregated_info, update_aggregated_info
 from ..utils.loss import TensorMapDictLoss
@@ -40,7 +39,7 @@ def _add_eval_model_parser(subparser: argparse._SubParsersAction) -> None:
     parser.add_argument(
         "model",
         type=load_exported_model,
-        help="Saved model to be evaluated.",
+        help="Saved exported model to be evaluated.",
     )
     parser.add_argument(
         "options",
@@ -60,10 +59,6 @@ def _add_eval_model_parser(subparser: argparse._SubParsersAction) -> None:
 
 def _eval_targets(model, dataset: Union[_BaseDataset, torch.utils.data.Subset]) -> None:
     """Evaluate an exported model on a dataset and print the RMSEs for each target."""
-
-    if not is_exported(model):
-        raise ValueError("The model must be exported to be used in `_eval_targets`.")
-
     # Attach neighbor lists to the structures:
     requested_neighbor_lists = model.requested_neighbors_lists()
     # working around https://github.com/lab-cosmo/metatensor/issues/521

--- a/src/metatensor/models/utils/model_io.py
+++ b/src/metatensor/models/utils/model_io.py
@@ -48,11 +48,11 @@ def load_checkpoint(path: Union[str, Path]) -> torch.nn.Module:
     if isinstance(path, str):
         path = Path(path)
 
-    if path.suffix == ".pt":
+    if path.suffix != ".ckpt":
         warnings.warn(
-            "Trying to load a checkpoint from a .pt file. This is probably "
-            "an exported model which will fail to train or export. Please "
-            "use a .ckpt (checkpoint) file instead.",
+            f"Trying to load a checkpoint from a {path.suffix} file. This is probably "
+            "not a checkpoint and will fail to train or export. Please use a `.ckpt` "
+            "(checkpoint) file instead.",
             stacklevel=1,
         )
 
@@ -88,12 +88,16 @@ def load_exported_model(
     if isinstance(path, str):
         path = Path(path)
 
-    if path.suffix == ".ckpt":
+    if path.suffix != ".pt":
         warnings.warn(
-            "Trying to load an exported model from a .ckpt file. This is "
-            "probably a checkpoint which will fail to load. Please export "
-            "the checkpoint with the `metatensor-models export` command.",
+            f"Trying to load an exported model from a {path.suffix} file. This is "
+            "probably not an exported model, and it will fail to load. If this is a "
+            "checkpoint (.ckpt), please export the checkpoint with the "
+            "`metatensor-models export` command.",
             stacklevel=1,
         )
 
-    return torch.jit.load(path)
+    try:
+        return torch.jit.load(path)
+    except RuntimeError as e:
+        raise ValueError(f"model at {path} is not exported") from e

--- a/tests/utils/test_model_io.py
+++ b/tests/utils/test_model_io.py
@@ -1,12 +1,19 @@
+import shutil
 from pathlib import Path
 
 import metatensor.torch
+import pytest
 import rascaline.torch
 from metatensor.torch.atomistic import ModelCapabilities, ModelOutput
 
 from metatensor.models.experimental import soap_bpnn
 from metatensor.models.utils.data import read_structures
-from metatensor.models.utils.model_io import load_checkpoint, save_model
+from metatensor.models.utils.export import is_exported
+from metatensor.models.utils.model_io import (
+    load_checkpoint,
+    load_exported_model,
+    save_model,
+)
 
 
 RESOURCES_PATH = Path(__file__).parent.resolve() / ".." / "resources"
@@ -46,3 +53,34 @@ def test_save_load_checkpoint(monkeypatch, tmp_path):
     assert metatensor.torch.allclose(
         output_before_save["energy"], output_after_load["energy"]
     )
+
+
+def test_load_checkpoint_wraning(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    # Create a model with "wrong" filending
+    shutil.copy(RESOURCES_PATH / "bpnn-model.ckpt", "model.pt")
+
+    with pytest.warns(match="Trying to load a checkpoint from a .pt file."):
+        load_checkpoint("model.pt")
+
+
+def test_load_exported_model():
+    model = load_exported_model(RESOURCES_PATH / "bpnn-model.pt")
+    assert is_exported(model)
+
+
+def test_load_exported_model_warning(monkeypatch, tmp_path):
+    """Test error raise if filesuffix is not the expected one."""
+    monkeypatch.chdir(tmp_path)
+
+    # Create a model with "wrong" filending
+    shutil.copy(RESOURCES_PATH / "bpnn-model.pt", "model.ckpt")
+
+    with pytest.warns(match="Trying to load an exported model from a .ckpt file."):
+        load_exported_model("model.ckpt")
+
+
+def test_load_exported_model_error():
+    with pytest.raises(ValueError, match="is not exported"):
+        load_exported_model(RESOURCES_PATH / "bpnn-model.ckpt")


### PR DESCRIPTION
Due to demo pressure tests were not implemented in #83 (see also [comment](https://github.com/lab-cosmo/metatensor-models/pull/83/files#r1494173809)).

This PR adds a first bunch of tests for `load_exported_model`.

Also missing tests the exporting will be done in a upcoming PR.



<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--98.org.readthedocs.build/en/98/

<!-- readthedocs-preview metatensor-models end -->