### PR TITLE
implementation of training on the per atom target quantities

### DIFF
--- a/src/metatensor/models/cli/conf/architecture/experimental.alchemical_model.yaml
+++ b/src/metatensor/models/cli/conf/architecture/experimental.alchemical_model.yaml
@@ -21,3 +21,4 @@ training:
   learning_rate: 0.001
   log_interval: 10
   checkpoint_interval: 25
+  peratom_targets: []

--- a/src/metatensor/models/cli/conf/architecture/experimental.soap_bpnn.yaml
+++ b/src/metatensor/models/cli/conf/architecture/experimental.soap_bpnn.yaml
@@ -25,3 +25,5 @@ training:
   learning_rate: 0.001
   log_interval: 10
   checkpoint_interval: 25
+  peratom_targets: 
+    - "energy"

--- a/src/metatensor/models/cli/conf/architecture/experimental.soap_bpnn.yaml
+++ b/src/metatensor/models/cli/conf/architecture/experimental.soap_bpnn.yaml
@@ -25,5 +25,4 @@ training:
   learning_rate: 0.001
   log_interval: 10
   checkpoint_interval: 25
-  peratom_targets: 
-    - "energy"
+  peratom_targets: []

--- a/src/metatensor/models/cli/eval_model.py
+++ b/src/metatensor/models/cli/eval_model.py
@@ -100,7 +100,7 @@ def _eval_targets(model, dataset: Union[_BaseDataset, torch.utils.data.Subset]) 
     aggregated_info: Dict[str, Tuple[float, int]] = {}
     for batch in dataloader:
         structures, targets = batch
-        _, info = compute_model_loss(loss_fn, model, structures, targets)
+        _, info = compute_model_loss(loss_fn, model, structures, targets, [])
         aggregated_info = update_aggregated_info(aggregated_info, info)
     finalized_info = finalize_aggregated_info(aggregated_info)
 

--- a/src/metatensor/models/cli/eval_model.py
+++ b/src/metatensor/models/cli/eval_model.py
@@ -100,15 +100,7 @@ def _eval_targets(model, dataset: Union[_BaseDataset, torch.utils.data.Subset]) 
     aggregated_info: Dict[str, Tuple[float, int]] = {}
     for batch in dataloader:
         structures, targets = batch
-        _, info = compute_model_loss(
-            loss_fn,
-            model,
-            structures,
-            targets,
-            [],
-            # TODO: modify evalulation routine to provide per atom RMSEs
-            # if requested
-        )
+        _, info = compute_model_loss(loss_fn, model, structures, targets, [])
         aggregated_info = update_aggregated_info(aggregated_info, info)
     finalized_info = finalize_aggregated_info(aggregated_info)
 

--- a/src/metatensor/models/cli/eval_model.py
+++ b/src/metatensor/models/cli/eval_model.py
@@ -100,7 +100,15 @@ def _eval_targets(model, dataset: Union[_BaseDataset, torch.utils.data.Subset]) 
     aggregated_info: Dict[str, Tuple[float, int]] = {}
     for batch in dataloader:
         structures, targets = batch
-        _, info = compute_model_loss(loss_fn, model, structures, targets, [])
+        _, info = compute_model_loss(
+            loss_fn,
+            model,
+            structures,
+            targets,
+            [],
+            # TODO: modify evalulation routine to provide per atom RMSEs
+            # if requested
+        )
         aggregated_info = update_aggregated_info(aggregated_info, info)
     finalized_info = finalize_aggregated_info(aggregated_info)
 

--- a/src/metatensor/models/experimental/alchemical_model/train.py
+++ b/src/metatensor/models/experimental/alchemical_model/train.py
@@ -209,7 +209,9 @@ def train(
             optimizer.zero_grad()
             structures, targets = batch
             assert len(structures[0].known_neighbors_lists()) > 0
-            loss, info = compute_model_loss(loss_fn, model, structures, targets, hypers_training["peratom_targets"])
+            loss, info = compute_model_loss(
+                loss_fn, model, structures, targets, hypers_training["peratom_targets"]
+            )
             train_loss += loss.item()
             loss.backward()
             optimizer.step()
@@ -220,7 +222,9 @@ def train(
         for batch in validation_dataloader:
             structures, targets = batch
             # TODO: specify that the model is not training here to save some autograd
-            loss, info = compute_model_loss(loss_fn, model, structures, targets, hypers_training["peratom_targets"])
+            loss, info = compute_model_loss(
+                loss_fn, model, structures, targets, hypers_training["peratom_targets"]
+            )
             validation_loss += loss.item()
             aggregated_validation_info = update_aggregated_info(
                 aggregated_validation_info, info

--- a/src/metatensor/models/experimental/alchemical_model/train.py
+++ b/src/metatensor/models/experimental/alchemical_model/train.py
@@ -209,7 +209,7 @@ def train(
             optimizer.zero_grad()
             structures, targets = batch
             assert len(structures[0].known_neighbors_lists()) > 0
-            loss, info = compute_model_loss(loss_fn, model, structures, targets)
+            loss, info = compute_model_loss(loss_fn, model, structures, targets, hypers_training["peratom_targets"])
             train_loss += loss.item()
             loss.backward()
             optimizer.step()
@@ -220,7 +220,7 @@ def train(
         for batch in validation_dataloader:
             structures, targets = batch
             # TODO: specify that the model is not training here to save some autograd
-            loss, info = compute_model_loss(loss_fn, model, structures, targets)
+            loss, info = compute_model_loss(loss_fn, model, structures, targets, hypers_training["peratom_targets"])
             validation_loss += loss.item()
             aggregated_validation_info = update_aggregated_info(
                 aggregated_validation_info, info

--- a/src/metatensor/models/experimental/soap_bpnn/train.py
+++ b/src/metatensor/models/experimental/soap_bpnn/train.py
@@ -74,6 +74,7 @@ def train(
 
     model_capabilities = model.capabilities
 
+
     # Perform checks on the datasets:
     logger.info("Checking datasets for consistency")
     check_datasets(
@@ -189,7 +190,7 @@ def train(
         for batch in train_dataloader:
             optimizer.zero_grad()
             structures, targets = batch
-            loss, info = compute_model_loss(loss_fn, model, structures, targets)
+            loss, info = compute_model_loss(loss_fn, model, structures, targets, hypers_training["peratom_targets"])
             train_loss += loss.item()
             loss.backward()
             optimizer.step()
@@ -200,7 +201,7 @@ def train(
         for batch in validation_dataloader:
             structures, targets = batch
             # TODO: specify that the model is not training here to save some autograd
-            loss, info = compute_model_loss(loss_fn, model, structures, targets)
+            loss, info = compute_model_loss(loss_fn, model, structures, targets, hypers_training["peratom_targets"])
             validation_loss += loss.item()
             aggregated_validation_info = update_aggregated_info(
                 aggregated_validation_info, info

--- a/src/metatensor/models/experimental/soap_bpnn/train.py
+++ b/src/metatensor/models/experimental/soap_bpnn/train.py
@@ -74,7 +74,6 @@ def train(
 
     model_capabilities = model.capabilities
 
-
     # Perform checks on the datasets:
     logger.info("Checking datasets for consistency")
     check_datasets(
@@ -190,7 +189,9 @@ def train(
         for batch in train_dataloader:
             optimizer.zero_grad()
             structures, targets = batch
-            loss, info = compute_model_loss(loss_fn, model, structures, targets, hypers_training["peratom_targets"])
+            loss, info = compute_model_loss(
+                loss_fn, model, structures, targets, hypers_training["peratom_targets"]
+            )
             train_loss += loss.item()
             loss.backward()
             optimizer.step()
@@ -201,7 +202,9 @@ def train(
         for batch in validation_dataloader:
             structures, targets = batch
             # TODO: specify that the model is not training here to save some autograd
-            loss, info = compute_model_loss(loss_fn, model, structures, targets, hypers_training["peratom_targets"])
+            loss, info = compute_model_loss(
+                loss_fn, model, structures, targets, hypers_training["peratom_targets"]
+            )
             validation_loss += loss.item()
             aggregated_validation_info = update_aggregated_info(
                 aggregated_validation_info, info

--- a/src/metatensor/models/utils/compute_loss.py
+++ b/src/metatensor/models/utils/compute_loss.py
@@ -28,6 +28,7 @@ def compute_model_loss(
     model: Union[torch.nn.Module, torch.jit._script.RecursiveScriptModule],
     systems: List[System],
     targets: Dict[str, TensorMap],
+    peratom_targets: List[str],
 ):
     """
     Compute the loss of a model on a set of targets.
@@ -108,6 +109,18 @@ def compute_model_loss(
 
     # Based on the keys of the targets, get the outputs of the model:
     model_outputs = _get_model_outputs(model, systems, list(targets.keys()))
+    
+    # modify model predictions and targets where averaging per atom is requested
+    if len(peratom_targets) > 0:
+    
+        num_atoms = torch.tensor([len(s) for s in systems]).to(device=device)
+        num_atoms = torch.reshape(num_atoms, (-1, 1))
+        
+        for pa_target in peratom_targets:
+            model_outputs[pa_target].block().values /= num_atoms
+            ## to prevent averaging builds up over epochs
+            targets = targets.copy()
+            targets[pa_target].block().values /= num_atoms
 
     for energy_target in energy_targets:
         # If the energy target requires gradients, compute them:

--- a/src/metatensor/models/utils/compute_loss.py
+++ b/src/metatensor/models/utils/compute_loss.py
@@ -115,16 +115,16 @@ def compute_model_loss(
 
     # Based on the keys of the targets, get the outputs of the model:
     model_outputs = _get_model_outputs(model, systems, list(targets.keys()))
-    
+
     # modify model predictions and targets where averaging per atom is requested
     if len(peratom_targets) > 0:
-    
+
         num_atoms = torch.tensor([len(s) for s in systems]).to(device=device)
         num_atoms = torch.reshape(num_atoms, (-1, 1))
-        
+
         for pa_target in peratom_targets:
             model_outputs[pa_target].block().values /= num_atoms
-            ## to prevent averaging builds up over epochs
+            # to prevent averaging builds up over epochs
             targets = targets.copy()
             targets[pa_target].block().values /= num_atoms
 

--- a/tests/utils/test_compute_loss.py
+++ b/tests/utils/test_compute_loss.py
@@ -96,9 +96,22 @@ def test_compute_model_loss():
         ),
     }
 
+    peratom_targets = []
+
     compute_model_loss(
         loss_fn,
         model,
         structures,
         targets,
+        peratom_targets,
+    )
+
+    peratom_targets = ["energy"]
+
+    compute_model_loss(
+        loss_fn,
+        model,
+        structures,
+        targets,
+        peratom_targets,
     )


### PR DESCRIPTION
Hello,

This PR is a first attempt at the implementation of training the models (SOAP-BPNN and alchemical) on the per atom targets for extensive quantities (e.g. energy) rather than the raw extensive values. Usefulness of this, apart from personal preferences in model training, is that it allows one to retain consistency between models in `metatensor-models` and default training behavior of `MACE`, `NequIP`, and other packages.

In the proposed solution, changes are summarized as follows:

- `peratom_targets`, a list of strings that contain targets that should be trained on the per atom values, is defined and accepted as an input to `comput_model_loss` function of `compute_loss.py`. The list can be supplied in the input yaml file.
- in the `compute_model_loss` function, model predictions and the target values are divided by the number of atoms before it is passed to `loss` then `MSELoss`.

I understand this may not be the most optimal solution to this. All suggestions are welcome in refactoring the feature.

Resolves #95 

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--101.org.readthedocs.build/en/101/

<!-- readthedocs-preview metatensor-models end -->