### PR TITLE
implement training on per atom energies by modifying loss modules

### DIFF
--- a/src/metatensor/models/cli/conf/architecture/experimental.alchemical_model.yaml
+++ b/src/metatensor/models/cli/conf/architecture/experimental.alchemical_model.yaml
@@ -18,3 +18,4 @@ training:
   learning_rate: 0.001
   log_interval: 10
   checkpoint_interval: 25
+  peratom_targets: []  

--- a/src/metatensor/models/cli/conf/architecture/experimental.soap_bpnn.yaml
+++ b/src/metatensor/models/cli/conf/architecture/experimental.soap_bpnn.yaml
@@ -25,3 +25,4 @@ training:
   learning_rate: 0.001
   log_interval: 10
   checkpoint_interval: 25
+  peratom_targets: []

--- a/src/metatensor/models/cli/eval_model.py
+++ b/src/metatensor/models/cli/eval_model.py
@@ -100,7 +100,7 @@ def _eval_targets(model, dataset: Union[_BaseDataset, torch.utils.data.Subset]) 
     aggregated_info: Dict[str, Tuple[float, int]] = {}
     for batch in dataloader:
         structures, targets = batch
-        _, info = compute_model_loss(loss_fn, model, structures, targets)
+        _, info = compute_model_loss(loss_fn, model, structures, targets, [])
         aggregated_info = update_aggregated_info(aggregated_info, info)
     finalized_info = finalize_aggregated_info(aggregated_info)
 

--- a/src/metatensor/models/experimental/alchemical_model/train.py
+++ b/src/metatensor/models/experimental/alchemical_model/train.py
@@ -209,7 +209,9 @@ def train(
             optimizer.zero_grad()
             structures, targets = batch
             assert len(structures[0].known_neighbors_lists()) > 0
-            loss, info = compute_model_loss(loss_fn, model, structures, targets)
+            loss, info = compute_model_loss(
+                loss_fn, model, structures, targets, hypers_training["peratom_targets"]
+            )
             train_loss += loss.item()
             loss.backward()
             optimizer.step()
@@ -220,7 +222,9 @@ def train(
         for batch in validation_dataloader:
             structures, targets = batch
             # TODO: specify that the model is not training here to save some autograd
-            loss, info = compute_model_loss(loss_fn, model, structures, targets)
+            loss, info = compute_model_loss(
+                loss_fn, model, structures, targets, hypers_training["peratom_targets"]
+            )
             validation_loss += loss.item()
             aggregated_validation_info = update_aggregated_info(
                 aggregated_validation_info, info

--- a/src/metatensor/models/experimental/soap_bpnn/train.py
+++ b/src/metatensor/models/experimental/soap_bpnn/train.py
@@ -189,7 +189,9 @@ def train(
         for batch in train_dataloader:
             optimizer.zero_grad()
             structures, targets = batch
-            loss, info = compute_model_loss(loss_fn, model, structures, targets)
+            loss, info = compute_model_loss(
+                loss_fn, model, structures, targets, hypers_training["peratom_targets"]
+            )
             train_loss += loss.item()
             loss.backward()
             optimizer.step()
@@ -200,7 +202,9 @@ def train(
         for batch in validation_dataloader:
             structures, targets = batch
             # TODO: specify that the model is not training here to save some autograd
-            loss, info = compute_model_loss(loss_fn, model, structures, targets)
+            loss, info = compute_model_loss(
+                loss_fn, model, structures, targets, hypers_training["peratom_targets"]
+            )
             validation_loss += loss.item()
             aggregated_validation_info = update_aggregated_info(
                 aggregated_validation_info, info

--- a/tests/utils/test_compute_loss.py
+++ b/tests/utils/test_compute_loss.py
@@ -96,9 +96,22 @@ def test_compute_model_loss():
         ),
     }
 
-    compute_model_loss(
+    loss, info = compute_model_loss(
         loss_fn,
         model,
         structures,
         targets,
+        [],
     )
+
+    peratom_targets = ["energy"]
+
+    peratom_loss, info = compute_model_loss(
+        loss_fn,
+        model,
+        structures,
+        targets,
+        peratom_targets,
+    )
+
+    assert loss > peratom_loss


### PR DESCRIPTION
Changes implemented here were discussed with @frostedoyster and @Luthaf.

Model training on per atom energies (or other extensive targets) can be achieved by specifying such `peratom_targets`, a list of strings, in the training section of the yaml files _of the models_. Note that this means future models that use the native training routine of `metatensor-models` should also specify this list in their yaml files as well.

Then, prior to computing the loss, this list is checked, and for the targets that have been specified, both the model prediction and the reference target values are divided by the number of atoms. This takes place towards the end of the `compute_model_loss` function.

Resolves #95 