### PR TITLE
Add shell completion

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install Zsh
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y zsh
+        touch ~/.zshrc
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ atomistic model.
 .. marker-documentation
 
 Documentation
-------------
+-------------
 
 For details, tutorials, and examples, please have a look at our
 `documentation <https://lab-cosmo.github.io/metatensor-models/latest/>`_.
@@ -97,6 +97,20 @@ example, to install the SOAP-BPNN model, you can run:
 .. code-block:: bash
 
     pip install .[soap-bpnn]
+
+Shell Completion
+################
+`metatensor-models` comes with completion definitions for its commands for ``bash`` and
+``zsh``. Since it is difficult to automatically configure shell completions in a robust
+manner, you must manually configure your shell to enable its completion support.
+
+To make the completions available, source the definitions as
+part of your shell's startup. Add the following to your ``~/.bash_profile``,
+``~/.zshrc`` (or, if they don't exist, ``~/.profile``):
+
+.. code-block:: bash
+
+  source $(metatensor-models --shell-completion)
 
 .. marker-issues
 

--- a/src/metatensor/models/__main__.py
+++ b/src/metatensor/models/__main__.py
@@ -3,6 +3,7 @@
 import argparse
 import sys
 import traceback
+from pathlib import Path
 
 from . import __version__
 from .cli.eval import _add_eval_model_parser, eval_model
@@ -20,6 +21,8 @@ def main():
     if len(sys.argv) < 2:
         ap.error("You must specify a sub-command")
 
+    # If you change the synopsis of these commands or add new ones adjust the completion
+    # script at `src/metatensor/models/share/metatensor-models-completion.bash`.
     ap.add_argument(
         "--version",
         action="version",
@@ -30,6 +33,13 @@ def main():
         "--debug",
         action="store_true",
         help="Run with debug options.",
+    )
+
+    ap.add_argument(
+        "--shell-completion",
+        action="version",
+        help="Path to the shell completion script",
+        version=str(Path(__file__).parent / "share/metatensor-models-completion.bash"),
     )
 
     # Add sub-parsers

--- a/src/metatensor/models/cli/eval.py
+++ b/src/metatensor/models/cli/eval.py
@@ -30,6 +30,8 @@ def _add_eval_model_parser(subparser: argparse._SubParsersAction) -> None:
     else:
         description = None
 
+    # If you change the synopsis of these commands or add new ones adjust the completion
+    # script at `src/metatensor/models/share/metatensor-models-completion.bash`.
     parser = subparser.add_parser(
         "eval",
         description=description,

--- a/src/metatensor/models/cli/export.py
+++ b/src/metatensor/models/cli/export.py
@@ -11,6 +11,8 @@ def _add_export_model_parser(subparser: argparse._SubParsersAction) -> None:
     else:
         description = None
 
+    # If you change the synopsis of these commands or add new ones adjust the completion
+    # script at `src/metatensor/models/share/metatensor-models-completion.bash`.
     parser = subparser.add_parser(
         "export",
         description=description,

--- a/src/metatensor/models/cli/train.py
+++ b/src/metatensor/models/cli/train.py
@@ -44,6 +44,8 @@ def _add_train_model_parser(subparser: argparse._SubParsersAction) -> None:
     else:
         description = None
 
+    # If you change the synopsis of these commands or add new ones adjust the completion
+    # script at `src/metatensor/models/share/metatensor-models-completion.bash`.
     parser = subparser.add_parser(
         "train",
         description=description,

--- a/src/metatensor/models/share/metatensor-models-completion.bash
+++ b/src/metatensor/models/share/metatensor-models-completion.bash
@@ -1,0 +1,101 @@
+_metatensor-models()
+{
+  local cur_word="${COMP_WORDS[$COMP_CWORD]}"
+  local prev_word="${COMP_WORDS[$COMP_CWORD-1]}"
+  local module="${COMP_WORDS[1]}"
+
+  # Define supported file endings.
+  local yaml='!*@(.yml|.yaml)'
+  local ckpt='!*.ckpt'
+  local pt='!*.pt'
+
+  # Complete the arguments to the module commands.
+  case "$module" in
+    train)
+      case "${prev_word}" in
+        -h|--help)
+          COMPREPLY=( )
+          return 0
+          ;;
+        -o|--output)
+          COMPREPLY=( )
+          return 0
+          ;;
+        -c|--continue)
+          COMPREPLY=( $( compgen -f -X "$ckpt" -- "${cur_word}") )
+          return 0
+          ;;
+        -y|--hydra)
+          COMPREPLY=( )
+          return 0
+          ;;
+        *)
+          if [[ $COMP_CWORD -eq 2 ]]; then
+            COMPREPLY=( $(compgen -f -X "$yaml" -- "${cur_word}") )
+            return 0
+          fi
+          ;;
+      esac
+      local opts="-h --help -o --output -c --continue -y --hydra"
+      COMPREPLY=( $(compgen -W "${opts}" -- "${cur_word}") )
+      return 0
+      ;;
+    export)
+      case "${prev_word}" in
+        -o|--output)
+          COMPREPLY=( )
+          return 0
+          ;;
+        -h|--help)
+          COMPREPLY=( )
+          return 0
+          ;;
+        *)
+          if [[ $COMP_CWORD -eq 2 ]]; then
+            COMPREPLY=( $(compgen -f -X "$ckpt" -- "${cur_word}") )
+            return 0
+          fi
+          ;;
+      esac
+      local opts="-h --help -o --output"
+      COMPREPLY=( $(compgen -W "${opts}" -- "${cur_word}") )
+      return 0
+      ;;
+    eval)
+      case "${prev_word}" in
+        -o|--output)
+          COMPREPLY=( )
+          return 0
+          ;;
+        -h|--help)
+          COMPREPLY=( )
+          return 0
+          ;;
+        *)
+          if [[ $COMP_CWORD -eq 2 ]]; then
+            COMPREPLY=( $(compgen -f -X "$pt" -- "${cur_word}") )
+            return 0
+          elif [[ $COMP_CWORD -eq 3 ]]; then
+            COMPREPLY=( $(compgen -f -X "$yaml" -- "${cur_word}") )
+            return 0
+          fi
+          ;;
+      esac
+      local opts="-h --help -o --output"
+      COMPREPLY=( $(compgen -W "${opts}" -- "${cur_word}") )
+      return 0
+      ;;
+  esac
+
+  # Complete the basic metatensor-models commands.
+  local opts="eval export train -h --help --debug --version"
+  COMPREPLY=( $(compgen -W "${opts}" -- "${cur_word}") )
+  return 0
+}
+
+if test -n "$ZSH_VERSION"; then
+  autoload -U +X compinit && compinit
+  autoload -U +X bashcompinit && bashcompinit
+fi
+
+complete -o bashdefault -F _metatensor-models metatensor-models

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,32 +1,110 @@
+"""Tests for argument parsing."""
+
+import shutil
 import subprocess
+from pathlib import Path
+from typing import List
 
 import pytest
 
 
-class Test_parse_args(object):
-    """Tests for argument parsing."""
+COMPFILE = (
+    Path(__file__).parents[2]
+    / "src/metatensor/models/share/metatensor-models-completion.bash"
+)
 
-    def test_required_args(self):
-        """Test required arguments."""
-        with pytest.raises(subprocess.CalledProcessError):
-            subprocess.check_call(["metatensor-models"])
 
-    def test_wrong_module(self):
-        """Test wrong module."""
-        with pytest.raises(subprocess.CalledProcessError):
-            subprocess.check_call(["metatensor-models", "foo"])
+def test_required_args():
+    """Test required arguments."""
+    with pytest.raises(subprocess.CalledProcessError):
+        subprocess.check_call(["metatensor-models"])
 
-    @pytest.mark.parametrize("module", tuple(["eval", "export", "train"]))
-    def test_available_modules(self, module):
-        """Test available modules."""
-        subprocess.check_call(["metatensor-models", module, "--help"])
 
-    @pytest.mark.parametrize("args", ("version", "help"))
-    def test_extra_options(self, args):
-        """Test extra options."""
-        subprocess.check_call(["metatensor-models", "--" + args])
+def test_wrong_module():
+    """Test wrong module."""
+    with pytest.raises(subprocess.CalledProcessError):
+        subprocess.check_call(["metatensor-models", "foo"])
 
-    @pytest.mark.parametrize("args", ("version", "help"))
-    def test_debug_flag(self, args):
-        """Test that even if debug flag is set commands run normal."""
-        subprocess.check_call(["metatensor-models", "--debug", "train", "-h"])
+
+@pytest.mark.parametrize("module", tuple(["eval", "export", "train"]))
+def test_available_modules(module):
+    """Test available modules."""
+    subprocess.check_call(["metatensor-models", module, "--help"])
+
+
+@pytest.mark.parametrize("args", ("version", "help"))
+def test_extra_options(args):
+    """Test extra options."""
+    subprocess.check_call(["metatensor-models", "--" + args])
+
+
+def test_debug_flag():
+    """Test that even if debug flag is set commands run normal."""
+    subprocess.check_call(["metatensor-models", "--debug", "train", "-h"])
+
+
+def test_shell_completion_flag():
+    """Test that path to the `shell-completion` is correct."""
+    completion_path = subprocess.check_output(
+        ["metatensor-models", "--shell-completion"]
+    )
+
+    assert Path(completion_path.decode("ascii")).is_file
+
+
+# TODO: There seems to be an issue with zsh, Github CI and subprocesses.
+@pytest.mark.parametrize(
+    "shell",
+    [
+        "bash",
+        pytest.param("zsh", marks=pytest.mark.xfail(reason="Github CI - zsh issue")),
+    ],
+)
+def test_syntax_completion(shell):
+    """Test that the completion can be sourced"""
+    subprocess.check_call(
+        args=[
+            shutil.which(shell),
+            "-i",
+            "-c",
+            "source $(metatensor-models --shell-completion)",
+        ],
+    )
+
+
+def get_completion_suggestions(partial_word: str) -> List[str]:
+    """Suggestions of a simulated <tab> completion of a metatensor-models subcommand.
+
+    https://stackoverflow.com/questions/9137245/unit-test-for-bash-completion-script
+    """
+    cmd = ["metatensor-models", partial_word]
+    cmdline = " ".join(cmd)
+
+    out = subprocess.Popen(
+        args=[
+            "bash",
+            "-i",
+            "-c",
+            r'source {compfile}; COMP_LINE="{cmdline}" COMP_WORDS=({cmdline}) '
+            r"COMP_CWORD={cword} COMP_POINT={cmdlen} $(complete -p {cmd} | "
+            r'sed "s/.*-F \\([^ ]*\\) .*/\\1/") && echo ${{COMPREPLY[*]}}'.format(
+                compfile=str(COMPFILE),
+                cmdline=cmdline,
+                cmdlen=len(cmdline),
+                cmd=cmd[0],
+                cword=cmd.index(partial_word),
+            ),
+        ],
+        stdout=subprocess.PIPE,
+    )
+    stdout, _ = out.communicate()
+    return stdout.decode("ascii").split()
+
+
+@pytest.mark.parametrize(
+    "partial_word, expected_completion",
+    [(" ", ["--debug", "--help", "--version", "-h", "eval", "export", "train"])],
+)
+def test_subcommand_completion(partial_word, expected_completion):
+    """Test that expected subcommand completion matches."""
+    assert set(get_completion_suggestions(partial_word)) == set(expected_completion)


### PR DESCRIPTION
Introduces a shell completion for `bash` and `zsh` for all metatensor-models command.

I try to check the commands carefully and there are tests for different shells but maybe somebody can give it a test drive on their local machine...

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--107.org.readthedocs.build/en/107/

<!-- readthedocs-preview metatensor-models end -->