### PR TITLE
Remove stray `torch.set_default_dtype()`

### DIFF
--- a/src/metatensor/models/__init__.py
+++ b/src/metatensor/models/__init__.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import torch
 
 PACKAGE_ROOT = Path(__file__).parent.resolve()
 
@@ -7,5 +6,3 @@ CONFIG_PATH = PACKAGE_ROOT / "cli" / "conf"
 ARCHITECTURE_CONFIG_PATH = CONFIG_PATH / "architecture"
 
 __version__ = "2023.11.29"
-
-torch.set_default_dtype(torch.float64)

--- a/src/metatensor/models/experimental/alchemical_model/tests/test_functionality.py
+++ b/src/metatensor/models/experimental/alchemical_model/tests/test_functionality.py
@@ -27,9 +27,9 @@ def test_prediction_subset():
         },
     )
 
-    alchemical_model = Model(capabilities, DEFAULT_HYPERS["model"]).to(torch.float64)
+    alchemical_model = Model(capabilities, DEFAULT_HYPERS["model"])
     structure = ase.Atoms("O2", positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
-    system = rascaline.torch.systems_to_torch(structure)
+    system = rascaline.torch.systems_to_torch(structure).to(torch.get_default_dtype())
     system = get_system_with_neighbors_lists(
         system, alchemical_model.requested_neighbors_lists()
     )

--- a/src/metatensor/models/experimental/alchemical_model/tests/test_invariance.py
+++ b/src/metatensor/models/experimental/alchemical_model/tests/test_invariance.py
@@ -29,15 +29,17 @@ def test_rotational_invariance():
             )
         },
     )
-    alchemical_model = Model(capabilities, DEFAULT_HYPERS["model"]).to(torch.float64)
+    alchemical_model = Model(capabilities, DEFAULT_HYPERS["model"])
     structure = ase.io.read(DATASET_PATH)
     original_structure = copy.deepcopy(structure)
     structure.rotate(48, "y")
-    original_system = rascaline.torch.systems_to_torch(original_structure)
+    original_system = rascaline.torch.systems_to_torch(original_structure).to(
+        torch.get_default_dtype()
+    )
     original_system = get_system_with_neighbors_lists(
         original_system, alchemical_model.requested_neighbors_lists()
     )
-    system = rascaline.torch.systems_to_torch(structure)
+    system = rascaline.torch.systems_to_torch(structure).to(torch.get_default_dtype())
     system = get_system_with_neighbors_lists(
         system, alchemical_model.requested_neighbors_lists()
     )

--- a/src/metatensor/models/experimental/soap_bpnn/tests/test_continue.py
+++ b/src/metatensor/models/experimental/soap_bpnn/tests/test_continue.py
@@ -1,5 +1,6 @@
 import shutil
 
+import torch
 from metatensor.learn.data import Dataset
 from metatensor.torch.atomistic import ModelCapabilities, ModelOutput
 from omegaconf import OmegaConf
@@ -20,7 +21,7 @@ def test_continue(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     shutil.copy(DATASET_PATH, "qm9_reduced_100.xyz")
 
-    structures = read_structures(DATASET_PATH)
+    structures = read_structures(DATASET_PATH, dtype=torch.get_default_dtype())
 
     capabilities = ModelCapabilities(
         length_unit="Angstrom",

--- a/src/metatensor/models/experimental/soap_bpnn/tests/test_functionality.py
+++ b/src/metatensor/models/experimental/soap_bpnn/tests/test_functionality.py
@@ -26,7 +26,7 @@ def test_prediction_subset_elements():
 
     structure = ase.Atoms("O2", positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
     soap_bpnn(
-        [rascaline.torch.systems_to_torch(structure)],
+        [rascaline.torch.systems_to_torch(structure).to(torch.get_default_dtype())],
         {"energy": soap_bpnn.capabilities.outputs["energy"]},
     )
 
@@ -56,7 +56,11 @@ def test_prediction_subset_atoms():
     )
 
     energy_monomer = soap_bpnn(
-        [rascaline.torch.systems_to_torch(structure_monomer)],
+        [
+            rascaline.torch.systems_to_torch(structure_monomer).to(
+                torch.get_default_dtype()
+            )
+        ],
         {"energy": soap_bpnn.capabilities.outputs["energy"]},
     )
 
@@ -78,12 +82,20 @@ def test_prediction_subset_atoms():
     )
 
     energy_dimer = soap_bpnn(
-        [rascaline.torch.systems_to_torch(structure_far_away_dimer)],
+        [
+            rascaline.torch.systems_to_torch(structure_far_away_dimer).to(
+                torch.get_default_dtype()
+            )
+        ],
         {"energy": soap_bpnn.capabilities.outputs["energy"]},
     )
 
     energy_monomer_in_dimer = soap_bpnn(
-        [rascaline.torch.systems_to_torch(structure_far_away_dimer)],
+        [
+            rascaline.torch.systems_to_torch(structure_far_away_dimer).to(
+                torch.get_default_dtype()
+            )
+        ],
         {"energy": soap_bpnn.capabilities.outputs["energy"]},
         selected_atoms=selection_labels,
     )


### PR DESCRIPTION
There was a `torch.set_default_dtype()` in the `__init__.py` of `metatensor-models`. All the other changes are tests that needed to be changed.

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--109.org.readthedocs.build/en/109/

<!-- readthedocs-preview metatensor-models end -->