### PR TITLE
Cleanup of omegconf and export functions

### DIFF
--- a/docs/src/getting-started/custom_dataset_conf.rst
+++ b/docs/src/getting-started/custom_dataset_conf.rst
@@ -70,7 +70,8 @@ Describes the system data like positions and cell information.
 :param read_from: The file containing system data.
 :param file_format: The file format, guessed from the suffix if ``null`` or not
     provided.
-:param length_unit: The unit of lengths, optional but recommended for simulations.
+:param length_unit: The unit of lengths, optional but highly recommended for running
+    simulations.
 
 A single string in this section automatically expands, using the string as the
 ``read_from`` parameter.
@@ -98,7 +99,8 @@ Target section parameters include:
 :param file_format: The file format, guessed from the suffix if not provided.
 :param key: The key for reading from the file, defaulting to the target section's name
   if not provided.
-:param unit: The unit of the target.
+:param unit: The unit of the target, optional but highly recommended for running
+    simulations.
 :param forces: Gradient sections. See :ref:`gradient-section` for parameters.
 :param stress: Gradient sections. See :ref:`gradient-section` for parameters.
 :param virial: Gradient sections. See :ref:`gradient-section` for parameters.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "metatensor-models"
 dynamic = ["version"]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 readme = "README.md"
 license = {text = "BSD-3-Clause"}

--- a/src/metatensor/models/utils/export.py
+++ b/src/metatensor/models/utils/export.py
@@ -13,10 +13,17 @@ def export(model: torch.nn.Module, output: str) -> None:
     :param output: Path to save the exported model
     """
 
+    if model.capabilities.length_unit == "":
+        warnings.warn(
+            "No `length_unit` was provided for the model. As a result, this model "
+            "output will be passed to MD engines as is.",
+            stacklevel=1,
+        )
+
     for model_output_name, model_output in model.capabilities.outputs.items():
         if model_output.unit == "":
             warnings.warn(
-                f"No units were provided for the `{model_output_name}` output. "
+                f"No target units were provided for output {model_output_name!r}. "
                 "As a result, this model output will be passed to MD engines as is.",
                 stacklevel=1,
             )

--- a/src/metatensor/models/utils/export.py
+++ b/src/metatensor/models/utils/export.py
@@ -15,8 +15,8 @@ def export(model: torch.nn.Module, output: str) -> None:
 
     if model.capabilities.length_unit == "":
         warnings.warn(
-            "No `length_unit` was provided for the model. As a result, this model "
-            "output will be passed to MD engines as is.",
+            "No `length_unit` was provided for the model. As a result, lengths "
+            "and any derived quantities will be passed to MD engines as is.",
             stacklevel=1,
         )
 

--- a/tests/cli/test_export_model.py
+++ b/tests/cli/test_export_model.py
@@ -25,16 +25,3 @@ def test_export(monkeypatch, tmp_path, output):
 
     subprocess.check_call(command)
     assert Path(output).is_file()
-
-
-def test_export_warning(monkeypatch, tmp_path):
-    """Test that the export cli raises an error when no units are present."""
-
-    monkeypatch.chdir(tmp_path)
-
-    out = subprocess.check_output(
-        ["metatensor-models", "export", str(RESOURCES_PATH / "bpnn-model.ckpt")],
-        stderr=subprocess.STDOUT,
-    )
-
-    assert "No units were provided" in str(out)

--- a/tests/utils/test_export.py
+++ b/tests/utils/test_export.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
-from metatensor.torch.atomistic import ModelCapabilities
+import pytest
+from metatensor.torch.atomistic import ModelCapabilities, ModelOutput
 
 from metatensor.models.experimental.soap_bpnn import Model
 from metatensor.models.utils.export import export, is_exported
@@ -12,11 +13,9 @@ RESOURCES_PATH = Path(__file__).parent.resolve() / ".." / "resources"
 
 def test_export(monkeypatch, tmp_path):
     """Tests the export function"""
-
-    model = Model(capabilities=ModelCapabilities(species=[1]))
-
     monkeypatch.chdir(tmp_path)
 
+    model = Model(capabilities=ModelCapabilities(species=[1], length_unit="angstrom"))
     export(model, "exported.pt")
 
     assert Path("exported.pt").is_file()
@@ -30,3 +29,25 @@ def test_is_exported():
 
     assert is_exported(exported_model)
     assert not is_exported(checkpoint)
+
+
+def test_length_units_warning(monkeypatch, tmp_path):
+    model = Model(capabilities=ModelCapabilities(species=[1]))
+
+    monkeypatch.chdir(tmp_path)
+    with pytest.warns(match="No `length_unit` was provided for the model."):
+        export(model, "exported.pt")
+
+
+def test_units_warning(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    outputs = {"output": ModelOutput(quantity="energy")}
+    model = Model(
+        capabilities=ModelCapabilities(
+            species=[1], outputs=outputs, length_unit="angstrom"
+        )
+    )
+
+    with pytest.warns(match="No target units were provided for output 'output'"):
+        export(model, "exported.pt")

--- a/tests/utils/test_omegaconf.py
+++ b/tests/utils/test_omegaconf.py
@@ -323,7 +323,7 @@ def test_check_options_list_length_unit(list_conf):
 
 
 def test_check_options_list_target_unit(list_conf):
-    # Test with three datasets where the second and the thirs are inconsistent.
+    """Test three datasets where the unit of the 2nd and the 3rd is inconsistent."""
     list_conf[1]["targets"]["new_target"] = OmegaConf.create({"unit": "foo"})
     list_conf[2]["targets"]["new_target"] = OmegaConf.create({"unit": "bar"})
 


### PR DESCRIPTION
This branch started with the goal adding checks for supported `length_unit`, `units` and `quantities` against what is supported by `metatensor.torch.atomistic`. 

While writing them, I noticed that these checks are implemented in metatensor atomistic already but are called not at initialization, but only when all capabilities are combined into an `MetatensorAtomisticModel`. My idea is to add checks for the supported `length_unit` at initialization of `metatensor.torch.atomistic.ModelCapabilities`. And, checks for `unit` and `quantity` at initialization of `metatensor.torch.atomistic.ModelOutput`.

What is left over  for this PR is some cleanup of our code...

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--112.org.readthedocs.build/en/112/

<!-- readthedocs-preview metatensor-models end -->