### PR TITLE
Update Python version for the alchemical model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ build-backend = "setuptools.build_meta"
 [project.optional-dependencies]
 soap-bpnn = []
 alchemical-model = [
-    python >= 3.9,
+    "python >= 3.9",
     "torch_alchemical @ git+https://github.com/abmazitov/torch_alchemical.git@fafb0bd",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,8 @@ build-backend = "setuptools.build_meta"
 [project.optional-dependencies]
 soap-bpnn = []
 alchemical-model = [
-  "torch_alchemical @ git+https://github.com/abmazitov/torch_alchemical.git@fafb0bd",
+    python >= 3.9
+    "torch_alchemical @ git+https://github.com/abmazitov/torch_alchemical.git@fafb0bd",
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ build-backend = "setuptools.build_meta"
 [project.optional-dependencies]
 soap-bpnn = []
 alchemical-model = [
-    python >= 3.9
+    python >= 3.9,
     "torch_alchemical @ git+https://github.com/abmazitov/torch_alchemical.git@fafb0bd",
 ]
 


### PR DESCRIPTION
The code of the alchemical model is using a lot of type hints that are only available to Python 3.9 and newer.
For example, `list[int]` (as opposed to `List[int]`) and `np.ndarray[str]`.
I have Python 3.8 and I can't train the alchemical model.

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--114.org.readthedocs.build/en/114/

<!-- readthedocs-preview metatensor-models end -->