### PR TITLE
Implement fixed composition weights provided by the user

### DIFF
--- a/src/metatensor/models/cli/conf/architecture/experimental.soap_bpnn.yaml
+++ b/src/metatensor/models/cli/conf/architecture/experimental.soap_bpnn.yaml
@@ -25,6 +25,7 @@ training:
   learning_rate: 0.001
   log_interval: 10
   checkpoint_interval: 25
+  fixed_composition_weights: {}
   per_atom_targets: []  # this specifies whether the model should be trained on a per-atom loss.
                         # In that case, the logger will also output per-atom metrics for that
                         # target. In any case, the final summary will be per-structure.


### PR DESCRIPTION
Hello,

This is an attempt at implementing the feature where users are able to define the composition weights used in training the  SOAP-BPNN model.

- User, if he/she desires, can specify a dictionary of dictionaries in the training section of the YAML, where the key to the sub-dictionary is the target, and sub-dictionary consists of species atomic numbers and their fixed composition weights.
- For a behavior where the use of composition weights is to be turned off, user can use this feature and set all weights of all species to 0.
- Checks if values are provided for all species present in the training dataset(s).

Resolves #108

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--129.org.readthedocs.build/en/129/

<!-- readthedocs-preview metatensor-models end -->