### PR TITLE
Pin rascaline version, limit metatensor version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,10 @@ dependencies = [
     "ase",
     "torch",
     "hydra-core",
-    "rascaline-torch @ git+https://github.com/luthaf/rascaline#subdirectory=python/rascaline-torch",
+    "rascaline-torch @ git+https://github.com/luthaf/rascaline@5ac2ee9#subdirectory=python/rascaline-torch",
     "metatensor-core",
-    "metatensor-operations",
-    "metatensor-torch",
+    "metatensor-operations <0.2",
+    "metatensor-torch <0.3",
     "metatensor-learn",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,9 @@ dependencies = [
     "hydra-core",
     "rascaline-torch @ git+https://github.com/luthaf/rascaline@5ac2ee9#subdirectory=python/rascaline-torch",
     "metatensor-core",
-    "metatensor-operations <0.2",
+    "metatensor-operations <0.2.1",
     "metatensor-torch <0.3",
-    "metatensor-learn",
+    "metatensor-learn <0.2.1",
 ]
 
 keywords = ["machine learning", "molecular modeling"]


### PR DESCRIPTION
The latest 0.3 release of metatensor-torch does not work with metatensor-models. This PR limits the version until we follow these changes.

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--133.org.readthedocs.build/en/133/

<!-- readthedocs-preview metatensor-models end -->