### PR TITLE
Use `extra` field for installing

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,8 +15,8 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: docs/src/conf.py
-   fail_on_warning: true
+  configuration: docs/src/conf.py
+  fail_on_warning: true
 
 
 # Declare the Python requirements required to build the docs.
@@ -24,7 +24,9 @@ sphinx:
 # PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
 # is declared in the project’s dashboard
 python:
-   install:
-   - method: pip
-     path: .[soap-bpnn]
-   - requirements: docs/requirements.txt
+  install:
+  - method: pip
+    path: .
+    extra_requirements:
+      - soap-bpnn
+  - requirements: docs/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -120,9 +120,8 @@ deps =
     -r docs/requirements.txt
 allowlist_externals =
     bash
+extras = soap-bpnn
 commands =
-    # SOAP-BPNN is required for the documentation
-    pip install .[soap-bpnn]
     # Run .sh scripts in the example folder.
     #bash -c "set -e && cd {toxinidir}/examples/basic_usage && bash usage.sh"
     # Disable slow training at runtime for ase example to speed up CI for now.


### PR DESCRIPTION
Using the `extra` fields for in the `readthedocs.yml` and `tox.ini` to make these configs a bit more readable.

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--142.org.readthedocs.build/en/142/

<!-- readthedocs-preview metatensor-models end -->