### PR TITLE
Disable rascaline logger during eval as well

### DIFF
--- a/src/metatensor/models/utils/model_io.py
+++ b/src/metatensor/models/utils/model_io.py
@@ -16,7 +16,10 @@ except ImportError:
     pass
 
 try:
+    import rascaline
     import rascaline.torch  # noqa: F401
+
+    rascaline.set_logging_callback(lambda x, y: None)
 except ImportError:
     pass
 


### PR DESCRIPTION
Without these changes, evaluating the SOAP-BPNN looks like this on my laptop:
```
filippo@C03DL22:~/metatensor-models/tests/resources$ metatensor-models eval bpnn-model.pt eval.yaml
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
[2024-03-13 18:02:06][INFO] - Setting up evaluation set.
[2024-03-13 18:02:06][INFO] - Evaluating dataset
[2024-03-13 18:02:06][WARNING] - Forces not found in section 'energy'. Continue without forces!
[2024-03-13 18:02:06][WARNING] - Stress not found in section 'energy'. Continue without stress!
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
[2024-03-13 18:02:14][INFO] - energy RMSE: 0.27898045890441614
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
rascaline::math::splines -- spline reached requested accuracy (1.000e-8) with 321 reference points (max absolute error is 5.699e-8)
```