### PR TITLE
Remove `set_default_dtype` and `get_default_dtype`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,8 +162,6 @@ cython_debug/
 # Don't save model outputs
 *.pt
 *.ckpt
-!tests/resources/*.pt
-!tests/resources/*.ckpt
 
 # model output directories
 outputs/

--- a/docs/src/getting-started/advanced_base_config.rst
+++ b/docs/src/getting-started/advanced_base_config.rst
@@ -8,13 +8,14 @@ be adjusted. They should be written without indentation in the ``options.yaml`` 
 
 :param device: The device in which the training should be run. Takes two possible
     values: ``cpu`` and ``gpu``. Default: ``cpu``
+:param base_precision: Override the base precision of all floats during training. By
+    default an optimal precision is obtained from the architecture. Changing this will
+    have an effect on the memory consumption during training and maybe also on the
+    accuracy of the model. Possible values: ``64``, ``32`` or ``16``.
 :param seed: Seed used to start the training. Set all the seeds
     of ``numpy.random``, ``random``, ``torch`` and ``torch.cuda`` (if available)
     to the same value ``seed``.
     If ``seed=None`` all the seeds are set to a random number. Default: ``None``
     Note: in a ``.yaml`` file ``None`` is ``null``.
-:param base_precision: This may increase the accuracy but will increase the
-    memory consumption during training. Possible values:
-    ``64``, ``32`` or ``16``. Default: ``64``
 
 In the next tutorials we show how to override the default parameters of an architecture.

--- a/src/metatensor/models/cli/conf/base.yaml
+++ b/src/metatensor/models/cli/conf/base.yaml
@@ -1,3 +1,3 @@
 device: "cpu"
-base_precision: 32
+base_precision: ${default_precision:}
 seed: null

--- a/src/metatensor/models/cli/conf/base.yaml
+++ b/src/metatensor/models/cli/conf/base.yaml
@@ -1,3 +1,3 @@
 device: "cpu"
-base_precision: 64
+base_precision: 32
 seed: null

--- a/src/metatensor/models/cli/eval.py
+++ b/src/metatensor/models/cli/eval.py
@@ -178,6 +178,10 @@ def eval_model(
         )
     logger.info("Setting up evaluation set.")
 
+    # TODO: once https://github.com/lab-cosmo/metatensor/pull/551 is merged and released
+    # use capabilities instead of this workaround
+    dtype = next(model.parameters()).dtype
+
     if isinstance(output, str):
         output = Path(output)
 
@@ -194,11 +198,12 @@ def eval_model(
         eval_systems = read_systems(
             filename=options["systems"]["read_from"],
             fileformat=options["systems"]["file_format"],
+            dtype=dtype,
         )
 
         # Predict targets
         if hasattr(options, "targets"):
-            eval_targets = read_targets(options["targets"])
+            eval_targets = read_targets(options["targets"], dtype=dtype)
             eval_dataset = Dataset(system=eval_systems, energy=eval_targets["energy"])
             _eval_targets(model, eval_dataset)
         else:

--- a/src/metatensor/models/cli/train.py
+++ b/src/metatensor/models/cli/train.py
@@ -207,11 +207,11 @@ def _train_model_hydra(options: DictConfig) -> None:
         necessary options for dataset preparation, model hyperparameters, and training.
     """
     if options["base_precision"] == 64:
-        torch.set_default_dtype(torch.float64)
+        dtype = torch.float64
     elif options["base_precision"] == 32:
-        torch.set_default_dtype(torch.float32)
+        dtype = torch.float32
     elif options["base_precision"] == 16:
-        torch.set_default_dtype(torch.float16)
+        dtype = torch.float16
     else:
         raise ValueError("Only 64, 32 or 16 are possible values for `base_precision`.")
 
@@ -239,11 +239,9 @@ def _train_model_hydra(options: DictConfig) -> None:
         train_systems = read_systems(
             filename=train_options["systems"]["read_from"],
             fileformat=train_options["systems"]["file_format"],
-            dtype=torch.get_default_dtype(),
+            dtype=dtype,
         )
-        train_targets = read_targets(
-            conf=train_options["targets"], dtype=torch.get_default_dtype()
-        )
+        train_targets = read_targets(conf=train_options["targets"], dtype=dtype)
         train_datasets.append(Dataset(system=train_systems, **train_targets))
 
     train_size = 1.0
@@ -293,11 +291,9 @@ def _train_model_hydra(options: DictConfig) -> None:
             test_systems = read_systems(
                 filename=test_options["systems"]["read_from"],
                 fileformat=test_options["systems"]["file_format"],
-                dtype=torch.get_default_dtype(),
+                dtype=dtype,
             )
-            test_targets = read_targets(
-                conf=test_options["targets"], dtype=torch.get_default_dtype()
-            )
+            test_targets = read_targets(conf=test_options["targets"], dtype=dtype)
             test_dataset = Dataset(system=test_systems, **test_targets)
             test_datasets.append(test_dataset)
 
@@ -346,10 +342,10 @@ def _train_model_hydra(options: DictConfig) -> None:
             validation_systems = read_systems(
                 filename=validation_options["systems"]["read_from"],
                 fileformat=validation_options["systems"]["file_format"],
-                dtype=torch.get_default_dtype(),
+                dtype=dtype,
             )
             validation_targets = read_targets(
-                conf=validation_options["targets"], dtype=torch.get_default_dtype()
+                conf=validation_options["targets"], dtype=dtype
             )
             validation_dataset = Dataset(
                 system=validation_systems, **validation_targets

--- a/src/metatensor/models/cli/train.py
+++ b/src/metatensor/models/cli/train.py
@@ -209,7 +209,7 @@ def _train_model_hydra(options: DictConfig) -> None:
 
     architecture_name = options["architecture"]["name"]
     architecture = importlib.import_module(f"metatensor.models.{architecture_name}")
-    architecture_capbilities = architecture.__ARCHITECTURE_CAPABILITIES__
+    architecture_capabilities = architecture.__ARCHITECTURE_CAPABILITIES__
 
     ###########################
     # PROCESS BASE PARAMETERS #
@@ -217,7 +217,7 @@ def _train_model_hydra(options: DictConfig) -> None:
     devices = pick_devices(
         requested_device=options["device"],
         available_devices=get_available_devices(),
-        architecture_devices=architecture_capbilities["supported_devices"],
+        architecture_devices=architecture_capabilities["supported_devices"],
     )
 
     # process dtypes
@@ -230,10 +230,10 @@ def _train_model_hydra(options: DictConfig) -> None:
     else:
         raise ValueError("Only 64, 32 or 16 are possible values for `base_precision`.")
 
-    if dtype not in architecture_capbilities["supported_dtypes"]:
+    if dtype not in architecture_capabilities["supported_dtypes"]:
         raise ValueError(
             f"Requested dtype {dtype} is not supported. {architecture_name} only "
-            f"supports {architecture_capbilities['supported_dtypes']}."
+            f"supports {architecture_capabilities['supported_dtypes']}."
         )
 
     if options["seed"] is not None:

--- a/src/metatensor/models/experimental/alchemical_model/__init__.py
+++ b/src/metatensor/models/experimental/alchemical_model/__init__.py
@@ -1,7 +1,12 @@
 from .model import Model, DEFAULT_HYPERS  # noqa: F401
 from .train import train  # noqa: F401
+import torch
 
-DEVICES = ["cuda", "cpu"]
+__ARCHITECTURE_CAPABILITIES__ = {
+    "supported_devices": ["cuda", "cpu"],
+    "supported_dtypes": [torch.float64, torch.float32],
+}
+
 
 __authors__ = [
     ("Arslan Mazitov <arslan.mazitov@epfl.ch>", "@abmazitov"),

--- a/src/metatensor/models/experimental/alchemical_model/tests/test_functionality.py
+++ b/src/metatensor/models/experimental/alchemical_model/tests/test_functionality.py
@@ -1,5 +1,4 @@
 import ase
-import torch
 from metatensor.torch.atomistic import (
     MetatensorAtomisticModel,
     ModelCapabilities,
@@ -31,7 +30,7 @@ def test_prediction_subset():
 
     alchemical_model = Model(capabilities, DEFAULT_HYPERS["model"])
     system = ase.Atoms("O2", positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
-    system = systems_to_torch(system, dtype=torch.get_default_dtype())
+    system = systems_to_torch(system)
     system = get_system_with_neighbors_lists(
         system, alchemical_model.requested_neighbors_lists()
     )

--- a/src/metatensor/models/experimental/alchemical_model/tests/test_invariance.py
+++ b/src/metatensor/models/experimental/alchemical_model/tests/test_invariance.py
@@ -35,11 +35,11 @@ def test_rotational_invariance():
     system = ase.io.read(DATASET_PATH)
     original_system = copy.deepcopy(system)
     system.rotate(48, "y")
-    original_system = systems_to_torch(original_system, dtype=torch.get_default_dtype())
+    original_system = systems_to_torch(original_system)
     original_system = get_system_with_neighbors_lists(
         original_system, alchemical_model.requested_neighbors_lists()
     )
-    system = systems_to_torch(system, dtype=torch.get_default_dtype())
+    system = systems_to_torch(system)
     system = get_system_with_neighbors_lists(
         system, alchemical_model.requested_neighbors_lists()
     )
@@ -63,7 +63,7 @@ def test_rotational_invariance():
         check_consistency=True,
     )
 
-    assert torch.allclose(
+    torch.testing.assert_close(
         original_output["energy"].block().values,
         rotated_output["energy"].block().values,
     )

--- a/src/metatensor/models/experimental/alchemical_model/tests/test_regression.py
+++ b/src/metatensor/models/experimental/alchemical_model/tests/test_regression.py
@@ -45,9 +45,7 @@ def test_regression_init():
 
     # Predict on the first five systems
     systems = ase.io.read(DATASET_PATH, ":5")
-    systems = [
-        systems_to_torch(system, dtype=torch.get_default_dtype()) for system in systems
-    ]
+    systems = [systems_to_torch(system) for system in systems]
     systems = [
         get_system_with_neighbors_lists(
             system, alchemical_model.requested_neighbors_lists()
@@ -71,7 +69,9 @@ def test_regression_init():
 
     expected_output = torch.tensor([[-1.9819], [0.1507], [1.6116], [3.4118], [0.8383]])
 
-    assert torch.allclose(output["U0"].block().values, expected_output, atol=1e-4)
+    torch.testing.assert_close(
+        output["U0"].block().values, expected_output, rtol=1e-05, atol=1e-4
+    )
 
 
 def test_regression_train():
@@ -83,7 +83,7 @@ def test_regression_train():
     np.random.seed(0)
     torch.manual_seed(0)
 
-    systems = read_systems(DATASET_PATH, dtype=torch.get_default_dtype())
+    systems = read_systems(DATASET_PATH)
     conf = {
         "U0": {
             "quantity": "energy",
@@ -95,7 +95,7 @@ def test_regression_train():
             "virial": False,
         }
     }
-    targets = read_targets(OmegaConf.create(conf), dtype=torch.get_default_dtype())
+    targets = read_targets(OmegaConf.create(conf))
     dataset = Dataset(system=systems, U0=targets["U0"])
 
     hypers = DEFAULT_HYPERS.copy()
@@ -137,4 +137,6 @@ def test_regression_train():
         [[-118.6454], [-106.1644], [-137.0310], [-164.7832], [-139.8678]]
     )
 
-    assert torch.allclose(output["U0"].block().values, expected_output, atol=1e-4)
+    torch.testing.assert_close(
+        output["U0"].block().values, expected_output, rtol=1e-05, atol=1e-4
+    )

--- a/src/metatensor/models/experimental/alchemical_model/tests/test_torch_alchemical_compatibility.py
+++ b/src/metatensor/models/experimental/alchemical_model/tests/test_torch_alchemical_compatibility.py
@@ -31,7 +31,7 @@ random.seed(0)
 np.random.seed(0)
 torch.manual_seed(0)
 
-systems = read_systems(DATASET_PATH, dtype=torch.get_default_dtype())
+systems = read_systems(DATASET_PATH)
 nl_options = NeighborsListOptions(
     cutoff=5.0,
     full_list=True,
@@ -50,18 +50,18 @@ batch = next(iter(dataloader))
 
 def test_systems_to_torch_alchemical_batch():
     batch_dict = systems_to_torch_alchemical_batch(systems, nl_options)
-    assert torch.allclose(batch_dict["positions"], batch.pos)
-    assert torch.allclose(batch_dict["cells"], batch.cell)
-    assert torch.allclose(batch_dict["numbers"], batch.numbers)
+    torch.testing.assert_close(batch_dict["positions"], batch.pos)
+    torch.testing.assert_close(batch_dict["cells"], batch.cell)
+    torch.testing.assert_close(batch_dict["numbers"], batch.numbers)
     index_1, counts_1 = torch.unique(batch_dict["batch"], return_counts=True)
     index_2, counts_2 = torch.unique(batch.batch, return_counts=True)
-    assert torch.allclose(index_1, index_2)
-    assert torch.allclose(counts_1, counts_2)
+    torch.testing.assert_close(index_1, index_2)
+    torch.testing.assert_close(counts_1, counts_2)
     offset_1, counts_1 = torch.unique(batch_dict["edge_offsets"], return_counts=True)
     offset_2, counts_2 = torch.unique(batch.edge_offsets, return_counts=True)
-    assert torch.allclose(offset_1, offset_2)
-    assert torch.allclose(counts_1, counts_2)
-    assert torch.allclose(batch_dict["batch"], batch.batch)
+    torch.testing.assert_close(offset_1, offset_2)
+    torch.testing.assert_close(counts_1, counts_2)
+    torch.testing.assert_close(batch_dict["batch"], batch.batch)
 
 
 def test_alchemical_model_inference():
@@ -114,4 +114,4 @@ def test_alchemical_model_inference():
         edge_offsets=batch.edge_offsets,
         batch=batch.batch,
     )
-    assert torch.allclose(output["energy"].block().values, original_output)
+    torch.testing.assert_close(output["energy"].block().values, original_output)

--- a/src/metatensor/models/experimental/alchemical_model/train.py
+++ b/src/metatensor/models/experimental/alchemical_model/train.py
@@ -120,8 +120,10 @@ def train(
     model.set_basis_normalization_factor(average_number_of_neighbors)
 
     device = devices[0]  # only one device, as we don't support multi-gpu for now
-    logger.info(f"Training on device {device}")
-    model.to(device)
+    dtype = train_datasets[0][0].system.positions.dtype
+
+    logger.info(f"training on device {device} with dtype {dtype}")
+    model.to(device=device, dtype=dtype)
 
     # Calculate and set the composition weights for all targets:
     for target_name in novel_capabilities.outputs.keys():

--- a/src/metatensor/models/experimental/alchemical_model/train.py
+++ b/src/metatensor/models/experimental/alchemical_model/train.py
@@ -90,12 +90,14 @@ def train(
 
     # Perform canonical checks on the datasets:
     logger.info("Checking datasets for consistency")
-    check_datasets(
-        train_datasets,
-        validation_datasets,
-        raise_incompatibility_error=continue_from is None,
-        # only error if we are not continuing
-    )
+    try:
+        check_datasets(train_datasets, validation_datasets)
+    except ValueError as err:
+        if continue_from is not None:
+            logger.warning(err)
+        else:
+            # only error if we are not continuing
+            raise ValueError(err) from err
 
     # Calculating the neighbors lists for the training and validation datasets:
     logger.info("Calculating neighbors lists for the datasets")

--- a/src/metatensor/models/experimental/alchemical_model/utils/normalize.py
+++ b/src/metatensor/models/experimental/alchemical_model/utils/normalize.py
@@ -16,13 +16,12 @@ def get_average_number_of_atoms(
     """
     average_number_of_atoms = []
     for dataset in datasets:
+        dtype = dataset[0].system.positions.dtype
         num_atoms = []
         for i in range(len(dataset)):
             system = dataset[i].system
             num_atoms.append(len(system))
-        average_number_of_atoms.append(
-            torch.mean(torch.tensor(num_atoms).to(torch.get_default_dtype()))
-        )
+        average_number_of_atoms.append(torch.mean(torch.tensor(num_atoms, dtype=dtype)))
     return torch.tensor(average_number_of_atoms)
 
 
@@ -38,6 +37,7 @@ def get_average_number_of_neighbors(
     average_number_of_neighbors = []
     for dataset in datasets:
         num_neighbors = []
+        dtype = dataset[0].system.positions.dtype
         for i in range(len(dataset)):
             system = dataset[i].system
             known_neighbors_lists = system.known_neighbors_lists()
@@ -51,7 +51,7 @@ def get_average_number_of_neighbors(
             num_neighbors.append(
                 torch.mean(
                     torch.unique(nl.samples["first_atom"], return_counts=True)[1].to(
-                        torch.get_default_dtype()
+                        dtype
                     )
                 )
             )

--- a/src/metatensor/models/experimental/pet/__init__.py
+++ b/src/metatensor/models/experimental/pet/__init__.py
@@ -1,7 +1,11 @@
 from .model import Model, DEFAULT_HYPERS  # noqa: F401
 from .train import train  # noqa: F401
+import torch
 
-DEVICES = ["cuda"]
+__ARCHITECTURE_CAPABILITIES__ = {
+    "supported_devices": ["cpu"],
+    "supported_dtypes": [torch.float32],
+}
 
 __authors__ = [
     ("Sergey Pozdnyakov <sergey.pozdnyakov@epfl.ch>", "@serfg"),

--- a/src/metatensor/models/experimental/pet/__init__.py
+++ b/src/metatensor/models/experimental/pet/__init__.py
@@ -3,7 +3,7 @@ from .train import train  # noqa: F401
 import torch
 
 __ARCHITECTURE_CAPABILITIES__ = {
-    "supported_devices": ["cpu"],
+    "supported_devices": ["cuda"],
     "supported_dtypes": [torch.float32],
 }
 

--- a/src/metatensor/models/experimental/pet/train.py
+++ b/src/metatensor/models/experimental/pet/train.py
@@ -27,7 +27,7 @@ def train(
     continue_from: Optional[str] = None,
     output_dir: str = ".",
 ):
-    if torch.get_default_dtype() != torch.float32:
+    if train_datasets[0][0].system.positions.dtype != torch.float32:
         raise ValueError("PET only supports float32")
     if len(dataset_info.targets) != 1:
         raise ValueError("PET only supports a single target")

--- a/src/metatensor/models/experimental/pet/train.py
+++ b/src/metatensor/models/experimental/pet/train.py
@@ -27,8 +27,6 @@ def train(
     continue_from: Optional[str] = None,
     output_dir: str = ".",
 ):
-    if train_datasets[0][0].system.positions.dtype != torch.float32:
-        raise ValueError("PET only supports float32")
     if len(dataset_info.targets) != 1:
         raise ValueError("PET only supports a single target")
     target_name = next(iter(dataset_info.targets.keys()))

--- a/src/metatensor/models/experimental/soap_bpnn/__init__.py
+++ b/src/metatensor/models/experimental/soap_bpnn/__init__.py
@@ -1,7 +1,11 @@
 from .model import Model, DEFAULT_HYPERS  # noqa: F401
 from .train import train  # noqa: F401
+import torch
 
-DEVICES = ["cuda", "cpu"]
+__ARCHITECTURE_CAPABILITIES__ = {
+    "supported_devices": ["cuda", "cpu"],
+    "supported_dtypes": [torch.float64, torch.float32],
+}
 
 __authors__ = [
     ("Filippo Bigi <filippo.bigi@epfl.ch>", "@frostedoyster"),

--- a/src/metatensor/models/experimental/soap_bpnn/tests/test_continue.py
+++ b/src/metatensor/models/experimental/soap_bpnn/tests/test_continue.py
@@ -22,7 +22,7 @@ def test_continue(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     shutil.copy(DATASET_PATH, "qm9_reduced_100.xyz")
 
-    systems = read_systems(DATASET_PATH, dtype=torch.get_default_dtype())
+    systems = read_systems(DATASET_PATH)
 
     capabilities = ModelCapabilities(
         length_unit="Angstrom",

--- a/src/metatensor/models/experimental/soap_bpnn/tests/test_functionality.py
+++ b/src/metatensor/models/experimental/soap_bpnn/tests/test_functionality.py
@@ -25,7 +25,7 @@ def test_prediction_subset_elements():
 
     system = ase.Atoms("O2", positions=[[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
     soap_bpnn(
-        [systems_to_torch(system, dtype=torch.get_default_dtype())],
+        [systems_to_torch(system)],
         {"energy": soap_bpnn.capabilities.outputs["energy"]},
     )
 
@@ -55,7 +55,7 @@ def test_prediction_subset_atoms():
     )
 
     energy_monomer = soap_bpnn(
-        [systems_to_torch(system_monomer).to(torch.get_default_dtype())],
+        [systems_to_torch(system_monomer)],
         {"energy": soap_bpnn.capabilities.outputs["energy"]},
     )
 
@@ -77,12 +77,12 @@ def test_prediction_subset_atoms():
     )
 
     energy_dimer = soap_bpnn(
-        [systems_to_torch(system_far_away_dimer).to(torch.get_default_dtype())],
+        [systems_to_torch(system_far_away_dimer)],
         {"energy": soap_bpnn.capabilities.outputs["energy"]},
     )
 
     energy_monomer_in_dimer = soap_bpnn(
-        [systems_to_torch(system_far_away_dimer).to(torch.get_default_dtype())],
+        [systems_to_torch(system_far_away_dimer)],
         {"energy": soap_bpnn.capabilities.outputs["energy"]},
         selected_atoms=selection_labels,
     )

--- a/src/metatensor/models/experimental/soap_bpnn/tests/test_invariance.py
+++ b/src/metatensor/models/experimental/soap_bpnn/tests/test_invariance.py
@@ -37,7 +37,7 @@ def test_rotational_invariance():
         {"energy": soap_bpnn.capabilities.outputs["energy"]},
     )
 
-    assert torch.allclose(
+    torch.testing.assert_close(
         original_output["energy"].block().values,
         rotated_output["energy"].block().values,
     )

--- a/src/metatensor/models/experimental/soap_bpnn/tests/test_regression.py
+++ b/src/metatensor/models/experimental/soap_bpnn/tests/test_regression.py
@@ -39,22 +39,21 @@ def test_regression_init():
     systems = ase.io.read(DATASET_PATH, ":5")
 
     output = soap_bpnn(
-        [
-            systems_to_torch(system, dtype=torch.get_default_dtype())
-            for system in systems
-        ],
+        [systems_to_torch(system) for system in systems],
         {"U0": soap_bpnn.capabilities.outputs["U0"]},
     )
     expected_output = torch.tensor([[0.0739], [0.0758], [0.1782], [-0.3517], [-0.3251]])
 
-    assert torch.allclose(output["U0"].block().values, expected_output, rtol=1e-3)
+    torch.testing.assert_close(
+        output["U0"].block().values, expected_output, rtol=1e-3, atol=1e-08
+    )
 
 
 def test_regression_train():
     """Perform a regression test on the model when
     trained for 2 epoch on a small dataset"""
 
-    systems = read_systems(DATASET_PATH, dtype=torch.get_default_dtype())
+    systems = read_systems(DATASET_PATH)
 
     conf = {
         "U0": {
@@ -67,7 +66,7 @@ def test_regression_train():
             "virial": False,
         }
     }
-    targets = read_targets(OmegaConf.create(conf), dtype=torch.get_default_dtype())
+    targets = read_targets(OmegaConf.create(conf))
     dataset = Dataset(system=systems, U0=targets["U0"])
 
     hypers = DEFAULT_HYPERS.copy()
@@ -91,4 +90,6 @@ def test_regression_train():
         [[-40.3951], [-56.4275], [-76.4008], [-77.3751], [-93.4227]]
     )
 
-    assert torch.allclose(output["U0"].block().values, expected_output, rtol=1e-3)
+    torch.testing.assert_close(
+        output["U0"].block().values, expected_output, rtol=1e-3, atol=1e-08
+    )

--- a/src/metatensor/models/experimental/soap_bpnn/train.py
+++ b/src/metatensor/models/experimental/soap_bpnn/train.py
@@ -94,12 +94,14 @@ def train(
 
     # Perform checks on the datasets:
     logger.info("Checking datasets for consistency")
-    check_datasets(
-        train_datasets,
-        validation_datasets,
-        raise_incompatibility_error=continue_from is None,
-        # only error if we are not continuing
-    )
+    try:
+        check_datasets(train_datasets, validation_datasets)
+    except ValueError as err:
+        if continue_from is not None:
+            logger.warning(err)
+        else:
+            # only error if we are not continuing
+            raise ValueError(err) from err
 
     device = devices[0]  # only one device, as we don't support multi-gpu for now
     dtype = train_datasets[0][0].system.positions.dtype

--- a/src/metatensor/models/experimental/soap_bpnn/train.py
+++ b/src/metatensor/models/experimental/soap_bpnn/train.py
@@ -102,8 +102,10 @@ def train(
     )
 
     device = devices[0]  # only one device, as we don't support multi-gpu for now
-    logger.info(f"Training on device {device}")
-    model.to(device)
+    dtype = train_datasets[0][0].system.positions.dtype
+
+    logger.info(f"training on device {device} with dtype {dtype}")
+    model.to(device=device, dtype=dtype)
 
     hypers_training = hypers["training"]
 
@@ -119,11 +121,10 @@ def train(
                 f"For {target_name}, model will proceed with "
                 "user-supplied composition weights"
             )
-
             cur_weight_dict = hypers_training["fixed_composition_weights"][target_name]
             species = []
             num_species = len(cur_weight_dict)
-            fixed_weights = torch.zeros(num_species, device=device)
+            fixed_weights = torch.zeros(num_species, dtype=dtype, device=device)
 
             for ii, (key, weight) in enumerate(cur_weight_dict.items()):
                 species.append(key)

--- a/src/metatensor/models/utils/data/dataset.py
+++ b/src/metatensor/models/utils/data/dataset.py
@@ -133,6 +133,7 @@ def check_datasets(
         (if ``false``) upon detection of a chemical species or target in the
         validation set that is not present in the training set.
     """
+    # TODO: Check that `dtypes` are consistent within datasets
 
     # Get all targets in the training and validation sets:
     train_targets = get_all_targets(train_datasets)

--- a/src/metatensor/models/utils/data/dataset.py
+++ b/src/metatensor/models/utils/data/dataset.py
@@ -111,13 +111,13 @@ def check_datasets(train_datasets: List[Dataset], validation_datasets: List[Data
     Although these checks will not fit all use cases, most models would be expected
     to be able to use this function.
 
-    :param train_datasets: A list of training datasets.
-    :param validation_datasets: A list of validation datasets.
+    :param train_datasets: A list of training datasets to check.
+    :param validation_datasets: A list of validation datasets to check
     :raises TypeError: If the ``dtype`` within the datasets are inconsistent.
     :raises ValueError: If the `validation_datasets` has a target that is not present in
         the ``train_datasets``.
     :raises ValueError: If the training or validation set contains chemical species
-    or targets that are not present in the training set
+        or targets that are not present in the training set
     """
     # Check that system `dtypes` are consistent within datasets
     desired_dtype = train_datasets[0][0].system.positions.dtype

--- a/src/metatensor/models/utils/data/dataset.py
+++ b/src/metatensor/models/utils/data/dataset.py
@@ -1,4 +1,3 @@
-import logging
 from dataclasses import dataclass
 from typing import Dict, List, NamedTuple, Optional, Tuple, Union
 
@@ -7,9 +6,6 @@ from metatensor.learn.data import Dataset, group_and_join
 from metatensor.torch import TensorMap
 from torch import Generator, default_generator
 from torch.utils.data import Subset, random_split
-
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -109,31 +105,32 @@ def collate_fn(batch: List[NamedTuple]) -> Tuple[List, Dict[str, TensorMap]]:
     return systems, collated_targets
 
 
-def check_datasets(
-    train_datasets: List[Dataset],
-    validation_datasets: List[Dataset],
-    raise_incompatibility_error: bool = True,
-):
-    """
-    This is a helper function that checks that the training and validation sets
-    are compatible with one another.
+def check_datasets(train_datasets: List[Dataset], validation_datasets: List[Dataset]):
+    """Check that the training and validation sets are compatible with one another
 
     Although these checks will not fit all use cases, most models would be expected
-    to be able to use this function. If the validation set contains chemical species
-    or targets that are not present in the training set, this function will raise a
-    warning or an error, depending on the ``raise_incompatibility_error`` flag.
-
-    The option to warn is intended for model fine tuning, where a species or target
-    in the validation set might not be present in the current training set, but it
-    might have been present in the training of the base model.
+    to be able to use this function. 
 
     :param train_datasets: A list of training datasets.
     :param validation_datasets: A list of validation datasets.
-    :param raise_incompatibility_error: Whether to error (if ``true``) or warn
-        (if ``false``) upon detection of a chemical species or target in the
-        validation set that is not present in the training set.
+    :raises TypeError: If the ``dtype`` within the datasets are inconsistent.
+    :raises ValueError: If the validation dataset has a target that is not present in
+        the training dataset.
+    :raises ValueError: If the training or validation set contains chemical species
+    or targets that are not present in the training set
     """
-    # TODO: Check that `dtypes` are consistent within datasets
+    # Check that system `dtypes` are consistent within datasets
+    desired_dtype = train_datasets[0][0].system.positions.dtype
+    msg = f"`dtype` between datasets is inconsistent, found {desired_dtype} and "
+    for train_dataset in train_datasets:
+        actual_dtype = train_dataset[0].system.positions.dtype
+        if actual_dtype != desired_dtype:
+            raise TypeError(f"{msg}{actual_dtype} found in `train_datasets`")
+        
+    for validation_dataset in validation_datasets:
+        actual_dtype = validation_dataset[0].system.positions.dtype
+        if actual_dtype != desired_dtype:
+            raise TypeError(f"{msg}{actual_dtype} found in `validation_datasets`")
 
     # Get all targets in the training and validation sets:
     train_targets = get_all_targets(train_datasets)
@@ -143,13 +140,10 @@ def check_datasets(
     # training sets:
     for target in validation_targets:
         if target not in train_targets:
-            error_or_warning = f"The validation dataset has a target ({target}) "
-            "that is not present in the training dataset."
-            if raise_incompatibility_error:
-                raise ValueError(error_or_warning)
-            else:
-                logger.warning(error_or_warning)
-
+            raise ValueError(
+                f"The validation dataset has a target ({target}) that is not present "
+                "in the training dataset."
+            )
     # Get all the species in the training and validation sets:
     all_training_species = get_all_species(train_datasets)
     all_validation_species = get_all_species(validation_datasets)
@@ -158,15 +152,11 @@ def check_datasets(
     # training sets:
     for species in all_validation_species:
         if species not in all_training_species:
-
-            error_or_warning = f"The validation dataset has a species ({species}) "
-            "that is not in the training dataset. This could be "
-            "a result of a random train/validation split. You can "
-            "avoid this by providing a validation dataset manually."
-            if raise_incompatibility_error:
-                raise ValueError(error_or_warning)
-            else:
-                logger.warning(error_or_warning)
+            raise ValueError(
+                f"The validation dataset has a species ({species}) that is not in the "
+                "training dataset. This could be a result of a random train/validation "
+                "split. You can avoid this by providing a validation dataset manually."
+            )
 
 
 def _train_test_random_split(

--- a/src/metatensor/models/utils/data/dataset.py
+++ b/src/metatensor/models/utils/data/dataset.py
@@ -109,13 +109,13 @@ def check_datasets(train_datasets: List[Dataset], validation_datasets: List[Data
     """Check that the training and validation sets are compatible with one another
 
     Although these checks will not fit all use cases, most models would be expected
-    to be able to use this function. 
+    to be able to use this function.
 
     :param train_datasets: A list of training datasets.
     :param validation_datasets: A list of validation datasets.
     :raises TypeError: If the ``dtype`` within the datasets are inconsistent.
-    :raises ValueError: If the validation dataset has a target that is not present in
-        the training dataset.
+    :raises ValueError: If the `validation_datasets` has a target that is not present in
+        the ``train_datasets``.
     :raises ValueError: If the training or validation set contains chemical species
     or targets that are not present in the training set
     """
@@ -126,7 +126,7 @@ def check_datasets(train_datasets: List[Dataset], validation_datasets: List[Data
         actual_dtype = train_dataset[0].system.positions.dtype
         if actual_dtype != desired_dtype:
             raise TypeError(f"{msg}{actual_dtype} found in `train_datasets`")
-        
+
     for validation_dataset in validation_datasets:
         actual_dtype = validation_dataset[0].system.positions.dtype
         if actual_dtype != desired_dtype:

--- a/src/metatensor/models/utils/data/readers/readers.py
+++ b/src/metatensor/models/utils/data/readers/readers.py
@@ -18,7 +18,7 @@ def _base_reader(
     readers: dict,
     filename: str,
     fileformat: Optional[str] = None,
-    dtype: torch.dtype = torch.float64,
+    dtype: torch.dtype = torch.float32,
     **reader_kwargs,
 ):
     if fileformat is None:
@@ -36,7 +36,7 @@ def read_energy(
     filename: str,
     target_value: str = "energy",
     fileformat: Optional[str] = None,
-    dtype: torch.dtype = torch.float64,
+    dtype: torch.dtype = torch.float32,
 ) -> List[TensorBlock]:
     """Read energy informations from a file.
 
@@ -60,7 +60,7 @@ def read_forces(
     filename: str,
     target_value: str = "forces",
     fileformat: Optional[str] = None,
-    dtype: torch.dtype = torch.float64,
+    dtype: torch.dtype = torch.float32,
 ) -> List[TensorBlock]:
     """Read force informations from a file.
 
@@ -84,7 +84,7 @@ def read_stress(
     filename: str,
     target_value: str = "stress",
     fileformat: Optional[str] = None,
-    dtype: torch.dtype = torch.float64,
+    dtype: torch.dtype = torch.float32,
 ) -> List[TensorBlock]:
     """Read stress informations from a file.
 
@@ -107,7 +107,7 @@ def read_stress(
 def read_systems(
     filename: str,
     fileformat: Optional[str] = None,
-    dtype: torch.dtype = torch.float64,
+    dtype: torch.dtype = torch.float32,
 ) -> List[System]:
     """Read system informations from a file.
 
@@ -129,7 +129,7 @@ def read_virial(
     filename: str,
     target_value: str = "virial",
     fileformat: Optional[str] = None,
-    dtype: torch.dtype = torch.float64,
+    dtype: torch.dtype = torch.float32,
 ) -> List[TensorBlock]:
     """Read virial informations from a file.
 
@@ -151,7 +151,7 @@ def read_virial(
 
 def read_targets(
     conf: DictConfig,
-    dtype: torch.dtype = torch.float64,
+    dtype: torch.dtype = torch.float32,
 ) -> Dict[str, List[TensorMap]]:
     """Reading all target information from a fully expanded config.
 

--- a/src/metatensor/models/utils/data/readers/systems/ase.py
+++ b/src/metatensor/models/utils/data/readers/systems/ase.py
@@ -5,7 +5,7 @@ import torch
 from metatensor.torch.atomistic import System, systems_to_torch
 
 
-def read_systems_ase(filename: str, dtype: torch.dtype = torch.float64) -> List[System]:
+def read_systems_ase(filename: str, dtype: torch.dtype = torch.float32) -> List[System]:
     """Store system informations using ase.
 
     :param filename: name of the file to read

--- a/src/metatensor/models/utils/data/readers/targets/ase.py
+++ b/src/metatensor/models/utils/data/readers/targets/ase.py
@@ -9,7 +9,7 @@ from metatensor.torch import Labels, TensorBlock
 def read_energy_ase(
     filename: str,
     key: str,
-    dtype: torch.dtype = torch.float64,
+    dtype: torch.dtype = torch.float32,
 ) -> List[TensorBlock]:
     """Store energy information in a List of :class:`metatensor.TensorBlock`.
 
@@ -43,7 +43,7 @@ def read_energy_ase(
 def read_forces_ase(
     filename: str,
     key: str = "energy",
-    dtype: torch.dtype = torch.float64,
+    dtype: torch.dtype = torch.float32,
 ) -> List[TensorBlock]:
     """Store force information in a List of :class:`metatensor.TensorBlock` which can be
     used as ``position`` gradients.
@@ -86,7 +86,7 @@ def read_forces_ase(
 def read_virial_ase(
     filename: str,
     key: str = "virial",
-    dtype: torch.dtype = torch.float64,
+    dtype: torch.dtype = torch.float32,
 ) -> List[TensorBlock]:
     """Store virial information in a List of :class:`metatensor.TensorBlock` which can
     be used as ``strain`` gradients.
@@ -106,7 +106,7 @@ def read_virial_ase(
 def read_stress_ase(
     filename: str,
     key: str = "stress",
-    dtype: torch.dtype = torch.float64,
+    dtype: torch.dtype = torch.float32,
 ) -> List[TensorBlock]:
     """Store stress information in a List of :class:`metatensor.TensorBlock` which can
     be used as ``strain`` gradients.
@@ -127,7 +127,7 @@ def _read_virial_stress_ase(
     filename: str,
     key: str,
     is_virial: bool = True,
-    dtype: torch.dtype = torch.float64,
+    dtype: torch.dtype = torch.float32,
 ) -> List[TensorBlock]:
     """Store stress or virial information in a List of :class:`metatensor.TensorBlock`
     which can be used as ``strain`` gradients.

--- a/tests/cli/test_eval_model.py
+++ b/tests/cli/test_eval_model.py
@@ -12,7 +12,7 @@ from metatensor.models.cli.eval import eval_model
 
 
 RESOURCES_PATH = Path(__file__).parent.resolve() / ".." / "resources"
-MODEL_PATH = RESOURCES_PATH / "bpnn-model.pt"
+MODEL_PATH = RESOURCES_PATH / "model-32-bit.pt"
 OPTIONS_PATH = RESOURCES_PATH / "eval.yaml"
 
 
@@ -45,12 +45,15 @@ def test_eval_cli(monkeypatch, tmp_path, capsys):
     assert Path("output.xyz").is_file()
 
 
-def test_eval(monkeypatch, tmp_path, caplog, model, options):
+@pytest.mark.parametrize("model_name", ["model-32-bit.pt", "model-64-bit.pt"])
+def test_eval(monkeypatch, tmp_path, caplog, model_name, options):
     """Test that eval via python API runs without an error raise."""
     monkeypatch.chdir(tmp_path)
     caplog.set_level(logging.INFO)
 
     shutil.copy(RESOURCES_PATH / "qm9_reduced_100.xyz", "qm9_reduced_100.xyz")
+
+    model = torch.jit.load(RESOURCES_PATH / model_name)
 
     eval_model(
         model=model,

--- a/tests/cli/test_export_model.py
+++ b/tests/cli/test_export_model.py
@@ -16,7 +16,7 @@ RESOURCES_PATH = Path(__file__).parent.resolve() / ".." / "resources"
 def test_export(monkeypatch, tmp_path, output):
     """Test that the export cli runs without an error raise."""
     monkeypatch.chdir(tmp_path)
-    command = ["metatensor-models", "export", str(RESOURCES_PATH / "bpnn-model.ckpt")]
+    command = ["metatensor-models", "export", str(RESOURCES_PATH / "model-32-bit.ckpt")]
 
     if output is not None:
         command += ["-o", output]

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -376,6 +376,16 @@ def test_different_base_precision(options, monkeypatch, tmp_path, base_precision
     train_model(options)
 
 
+def test_unsupported_dtype(options):
+    options["base_precision"] = 16
+    match = (
+        r"Requested dtype torch.float16 is not supported. experimental.soap_bpnn "
+        r"only supports \[torch.float64, torch.float32\]."
+    )
+    with pytest.raises(ValueError, match=match):
+        train_model(options)
+
+
 def test_architecture_error(options, monkeypatch, tmp_path):
     """Test an error raise if there is problem wth the architecture."""
     monkeypatch.chdir(tmp_path)

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -18,7 +18,7 @@ RESOURCES_PATH = Path(__file__).parent.resolve() / ".." / "resources"
 DATASET_PATH = RESOURCES_PATH / "qm9_reduced_100.xyz"
 DATASET_PATH_2 = RESOURCES_PATH / "ethanol_reduced_100.xyz"
 OPTIONS_PATH = RESOURCES_PATH / "options.yaml"
-MODEL_PATH = RESOURCES_PATH / "bpnn-model.ckpt"
+MODEL_PATH = RESOURCES_PATH / "model-32-bit.ckpt"
 
 
 @pytest.fixture

--- a/tests/cli/test_train_model.py
+++ b/tests/cli/test_train_model.py
@@ -348,12 +348,12 @@ def test_model_consistency_with_seed(
         # The first tensor only depend on the chemical compositions (not on the
         # seed) and should alwyas be the same.
         if index == 0:
-            assert torch.allclose(tensor1, tensor2)
+            torch.testing.assert_close(tensor1, tensor2)
         else:
             if seed is None:
                 assert not torch.allclose(tensor1, tensor2)
             else:
-                assert torch.allclose(tensor1, tensor2)
+                torch.testing.assert_close(tensor1, tensor2)
 
 
 def test_error_base_precision(options, monkeypatch, tmp_path):
@@ -364,6 +364,16 @@ def test_error_base_precision(options, monkeypatch, tmp_path):
 
     with pytest.raises(ValueError, match="Only 64, 32 or 16 are possible values for"):
         train_model(options)
+
+
+# TODO add parametrize for 16-bit once we have a model that supports this.
+@pytest.mark.parametrize("base_precision", [64])
+def test_different_base_precision(options, monkeypatch, tmp_path, base_precision):
+    """Test different `base_precision`s."""
+    monkeypatch.chdir(tmp_path)
+    shutil.copy(DATASET_PATH, "qm9_reduced_100.xyz")
+    options["base_precision"] = base_precision
+    train_model(options)
 
 
 def test_architecture_error(options, monkeypatch, tmp_path):

--- a/tests/resources/generate-outputs.sh
+++ b/tests/resources/generate-outputs.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 set -e
 
+echo "Generate data for testing..."
+
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 cd $ROOT_DIR
 
-metatensor-models train options.yaml -o model-32-bit.pt -y base_precision=32
-metatensor-models train options.yaml -o model-64-bit.pt -y base_precision=64
+metatensor-models train options.yaml -o model-32-bit.pt -y base_precision=32 > /dev/null
+metatensor-models train options.yaml -o model-64-bit.pt -y base_precision=64 > /dev/null

--- a/tests/resources/generate-outputs.sh
+++ b/tests/resources/generate-outputs.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
+set -e
 
 cd `dirname "$(realpath $0)"`
+
+pwd
 
 metatensor-models train options.yaml -o model-32-bit.pt -y base_precision=32
 metatensor-models train options.yaml -o model-64-bit.pt -y base_precision=64

--- a/tests/resources/generate-outputs.sh
+++ b/tests/resources/generate-outputs.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 cd `dirname "$(realpath $0)"`
 

--- a/tests/resources/generate-outputs.sh
+++ b/tests/resources/generate-outputs.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
 
-cd `dirname "$(realpath $0)"`
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-pwd
+cd $ROOT_DIR
 
 metatensor-models train options.yaml -o model-32-bit.pt -y base_precision=32
 metatensor-models train options.yaml -o model-64-bit.pt -y base_precision=64

--- a/tests/resources/generate-outputs.sh
+++ b/tests/resources/generate-outputs.sh
@@ -1,0 +1,6 @@
+#/bin/bash
+
+cd `dirname "$(realpath $0)"`
+
+metatensor-models train options.yaml -o model-32-bit.pt -y base_precision=32
+metatensor-models train options.yaml -o model-64-bit.pt -y base_precision=64

--- a/tests/resources/options.yaml
+++ b/tests/resources/options.yaml
@@ -1,5 +1,3 @@
-base_precision: 32
-
 architecture:
   name: experimental.soap_bpnn
   training:
@@ -8,10 +6,12 @@ architecture:
 
 training_set:
   systems:
-    read_from: "qm9_reduced_100.xyz"
+    read_from: qm9_reduced_100.xyz
+    length_unit: angstrom
   targets:
     energy:
-      key: "U0"
+      key: U0
+      unit: eV
 
 test_set: 0.5
 validation_set: 0.1

--- a/tests/resources/options.yaml
+++ b/tests/resources/options.yaml
@@ -1,3 +1,5 @@
+base_precision: 32
+
 architecture:
   name: experimental.soap_bpnn
   training:

--- a/tests/utils/data/structures/test_structures_ase.py
+++ b/tests/utils/data/structures/test_structures_ase.py
@@ -27,5 +27,10 @@ def test_read_ase(monkeypatch, tmp_path):
     assert len(result) == 1
     assert isinstance(result[0], torch.ScriptObject)
 
-    torch.testing.assert_close(result[0].positions, torch.tensor(systems.positions))
-    torch.testing.assert_close(result[0].types, torch.tensor([1, 1], dtype=torch.int32))
+    positions_actual = result[0].positions
+    positions_expected = torch.tensor(systems.positions, dtype=positions_actual.dtype)
+    torch.testing.assert_close(positions_actual, positions_expected)
+
+    types_expected = result[0].types
+    types_actual = torch.tensor([1, 1], dtype=types_expected.dtype)
+    torch.testing.assert_close(types_expected, types_actual)

--- a/tests/utils/data/targets/test_targets_ase.py
+++ b/tests/utils/data/targets/test_targets_ase.py
@@ -123,9 +123,7 @@ def test_read_virial_warn(monkeypatch, tmp_path):
     ase.io.write(filename, systems)
 
     with pytest.warns(match="Found 9-long numerical vector"):
-        results = read_virial_ase(
-            filename=filename, key="stress-9", dtype=torch.get_default_dtype()
-        )
+        results = read_virial_ase(filename=filename, key="stress-9")
 
     expected = -torch.tensor(systems.info["stress-9"])
     expected = expected.reshape(-1, 3, 3, 1)

--- a/tests/utils/data/test_dataset.py
+++ b/tests/utils/data/test_dataset.py
@@ -186,7 +186,8 @@ def test_check_datasets():
 
     # wrong dtype
     systems_qm9_64_bit = read_systems(
-        RESOURCES_PATH / "qm9_reduced_100.xyz", dtype=torch.float64)
+        RESOURCES_PATH / "qm9_reduced_100.xyz", dtype=torch.float64
+    )
     training_set_64_bit = Dataset(system=systems_qm9_64_bit, **targets_qm9)
     match = (
         "`dtype` between datasets is inconsistent, found torch.float32 and "
@@ -201,5 +202,3 @@ def test_check_datasets():
     )
     with pytest.raises(TypeError, match=match):
         check_datasets([training_set, training_set_64_bit], [validation_set])
-
-

--- a/tests/utils/data/test_dataset.py
+++ b/tests/utils/data/test_dataset.py
@@ -137,8 +137,7 @@ def test_get_all_targets():
     assert get_all_targets([dataset, dataset_2]) == ["U0", "energy"]
 
 
-@pytest.mark.parametrize("raise_incompatibility_error", [True, False])
-def test_check_datasets(raise_incompatibility_error):
+def test_check_datasets():
     """Tests the check_datasets function."""
 
     systems_qm9 = read_systems(RESOURCES_PATH / "qm9_reduced_100.xyz")
@@ -171,26 +170,36 @@ def test_check_datasets(raise_incompatibility_error):
     # everything ok
     training_set = Dataset(system=systems_qm9, **targets_qm9)
     validation_set = Dataset(system=systems_qm9, **targets_qm9)
-    check_datasets([training_set], [validation_set], raise_incompatibility_error)
+    check_datasets([training_set], [validation_set])
 
     # extra species in validation dataset
     training_set = Dataset(system=systems_ethanol, **targets_qm9)
     validation_set = Dataset(system=systems_qm9, **targets_qm9)
-    if raise_incompatibility_error:
-        with pytest.raises(ValueError, match="The validation dataset has a species"):
-            check_datasets(
-                [training_set], [validation_set], raise_incompatibility_error
-            )
-    else:
-        check_datasets([training_set], [validation_set], raise_incompatibility_error)
+    with pytest.raises(ValueError, match="The validation dataset has a species"):
+        check_datasets([training_set], [validation_set])
 
     # extra targets in validation dataset
     training_set = Dataset(system=systems_qm9, **targets_qm9)
     validation_set = Dataset(system=systems_qm9, **targets_ethanol)
-    if raise_incompatibility_error:
-        with pytest.raises(ValueError, match="The validation dataset has a target"):
-            check_datasets(
-                [training_set], [validation_set], raise_incompatibility_error
-            )
-    else:
-        check_datasets([training_set], [validation_set], raise_incompatibility_error)
+    with pytest.raises(ValueError, match="The validation dataset has a target"):
+        check_datasets([training_set], [validation_set])
+
+    # wrong dtype
+    systems_qm9_64_bit = read_systems(
+        RESOURCES_PATH / "qm9_reduced_100.xyz", dtype=torch.float64)
+    training_set_64_bit = Dataset(system=systems_qm9_64_bit, **targets_qm9)
+    match = (
+        "`dtype` between datasets is inconsistent, found torch.float32 and "
+        "torch.float64 found in `validation_datasets`"
+    )
+    with pytest.raises(TypeError, match=match):
+        check_datasets([training_set], [training_set_64_bit])
+
+    match = (
+        "`dtype` between datasets is inconsistent, found torch.float32 and "
+        "torch.float64 found in `train_datasets`"
+    )
+    with pytest.raises(TypeError, match=match):
+        check_datasets([training_set, training_set_64_bit], [validation_set])
+
+

--- a/tests/utils/data/test_target_writers.py
+++ b/tests/utils/data/test_target_writers.py
@@ -56,8 +56,8 @@ def test_write_xyz(monkeypatch, tmp_path):
 def test_write_xyz_cell(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
 
-    cell = torch.ones(3, 3)
-    systems, predictions = systems_predictions(cell=cell)
+    cell_expected = torch.ones(3, 3)
+    systems, predictions = systems_predictions(cell=cell_expected)
 
     filename = "test_output.xyz"
 
@@ -66,9 +66,8 @@ def test_write_xyz_cell(monkeypatch, tmp_path):
     # Read the file and verify its contents
     frames = ase.io.read(filename, index=":")
     for atoms in frames:
-        torch.testing.assert_close(
-            torch.tensor(atoms.cell[:], dtype=torch.get_default_dtype()), cell
-        )
+        cell_actual = torch.tensor(atoms.cell, dtype=cell_expected.dtype)
+        torch.testing.assert_close(cell_actual, cell_expected)
         assert all(atoms.pbc == 3 * [True])
 
 

--- a/tests/utils/test_composition.py
+++ b/tests/utils/test_composition.py
@@ -68,4 +68,4 @@ def test_calculate_composition_weights():
     assert len(weights) == len(species)
     assert len(weights) == 2
     assert species == [1, 8]
-    assert torch.allclose(weights, torch.tensor([2.0, 1.0]))
+    torch.testing.assert_close(weights, torch.tensor([2.0, 1.0]))

--- a/tests/utils/test_compute_loss.py
+++ b/tests/utils/test_compute_loss.py
@@ -36,9 +36,7 @@ def test_compute_model_loss():
     model = soap_bpnn.Model(capabilities)
     # model = torch.jit.script(model)  # jit the model for good measure
 
-    systems = read_systems(
-        RESOURCES_PATH / "alchemical_reduced_10.xyz", dtype=torch.get_default_dtype()
-    )[:2]
+    systems = read_systems(RESOURCES_PATH / "alchemical_reduced_10.xyz")[:2]
 
     gradient_samples = Labels(
         names=["sample", "atom"],

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import metatensor.torch
 import pytest
-import torch
 from metatensor.torch.atomistic import ModelCapabilities, ModelOutput
 
 from metatensor.models.experimental.soap_bpnn import Model
@@ -30,9 +29,7 @@ def test_save_load_checkpoint(monkeypatch, tmp_path, path):
     )
 
     model = Model(capabilities)
-    systems = read_systems(
-        RESOURCES_PATH / "qm9_reduced_100.xyz", dtype=torch.get_default_dtype()
-    )
+    systems = read_systems(RESOURCES_PATH / "qm9_reduced_100.xyz")
 
     output_before_save = model(
         systems,

--- a/tests/utils/test_io.py
+++ b/tests/utils/test_io.py
@@ -72,7 +72,8 @@ def test_missing_extension(monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize(
-    "path", [RESOURCES_PATH / "bpnn-model.pt", str(RESOURCES_PATH / "bpnn-model.pt")]
+    "path",
+    [RESOURCES_PATH / "model-32-bit.pt", str(RESOURCES_PATH / "model-32-bit.pt")],
 )
 def test_load_exported_model(path):
     model = load(path)
@@ -135,8 +136,8 @@ def test_reexport(monkeypatch, tmp_path):
 def test_is_exported():
     """Tests the is_exported function"""
 
-    checkpoint = load(RESOURCES_PATH / "bpnn-model.ckpt")
-    exported_model = load(RESOURCES_PATH / "bpnn-model.pt")
+    checkpoint = load(RESOURCES_PATH / "model-32-bit.ckpt")
+    exported_model = load(RESOURCES_PATH / "model-32-bit.pt")
 
     assert is_exported(exported_model)
     assert not is_exported(checkpoint)

--- a/tests/utils/test_loss.py
+++ b/tests/utils/test_loss.py
@@ -122,12 +122,12 @@ def test_tmap_loss_no_gradients():
     )
 
     loss_value, info = loss(tensor_map_1, tensor_map_1)
-    assert torch.allclose(loss_value, torch.tensor(0.0))
+    torch.testing.assert_close(loss_value, torch.tensor(0.0))
     assert set(info.keys()) == set(["values"])
 
     # Expected result: 1.0/3.0 (there are three values)
     loss_value, info = loss(tensor_map_1, tensor_map_2)
-    assert torch.allclose(loss_value, torch.tensor(1.0 / 3.0))
+    torch.testing.assert_close(loss_value, torch.tensor(1.0 / 3.0))
     assert set(info.keys()) == set(["values"])
 
 
@@ -136,12 +136,12 @@ def test_tmap_loss_with_gradients(tensor_map_with_grad_1, tensor_map_with_grad_2
     loss = TensorMapLoss(gradient_weights={"gradient": 0.5})
 
     loss_value, info = loss(tensor_map_with_grad_1, tensor_map_with_grad_1)
-    assert torch.allclose(loss_value, torch.tensor(0.0))
+    torch.testing.assert_close(loss_value, torch.tensor(0.0))
     assert set(info.keys()) == set(["values", "gradient"])
 
     # Expected result: 1.0/3.0 + 0.5 * 4.0 / 3.0 (there are three values)
     loss_value, info = loss(tensor_map_with_grad_1, tensor_map_with_grad_2)
-    assert torch.allclose(
+    torch.testing.assert_close(
         loss_value,
         torch.tensor(1.0 / 3.0 + 0.5 * 4.0 / 3.0),
     )
@@ -205,7 +205,7 @@ def test_tmap_dict_loss(
     )
 
     loss_value, info = loss(output_dict, target_dict)
-    assert torch.allclose(loss_value, expected_result)
+    torch.testing.assert_close(loss_value, expected_result)
     assert set(info.keys()) == set(
         [
             "output_1",
@@ -253,5 +253,5 @@ def test_tmap_dict_loss_subset(tensor_map_with_grad_1, tensor_map_with_grad_3):
     )
 
     loss_value, info = loss(output_dict, target_dict)
-    assert torch.allclose(loss_value, expected_result)
+    torch.testing.assert_close(loss_value, expected_result)
     assert set(info.keys()) == set(["output_1", "output_1_gradient_gradients"])

--- a/tests/utils/test_output_gradient.py
+++ b/tests/utils/test_output_gradient.py
@@ -29,9 +29,7 @@ def test_forces(is_training):
     )
 
     model = soap_bpnn.Model(capabilities)
-    systems = read_systems(
-        RESOURCES_PATH / "qm9_reduced_100.xyz", dtype=torch.get_default_dtype()
-    )[:5]
+    systems = read_systems(RESOURCES_PATH / "qm9_reduced_100.xyz")[:5]
     systems = [
         System(
             positions=system.positions.requires_grad_(True),
@@ -49,9 +47,7 @@ def test_forces(is_training):
     forces = [-position_gradient for position_gradient in position_gradients]
 
     jitted_model = torch.jit.script(model)
-    systems = read_systems(
-        RESOURCES_PATH / "qm9_reduced_100.xyz", dtype=torch.get_default_dtype()
-    )[:5]
+    systems = read_systems(RESOURCES_PATH / "qm9_reduced_100.xyz")[:5]
     systems = [
         System(
             positions=system.positions.requires_grad_(True),
@@ -71,7 +67,7 @@ def test_forces(is_training):
     ]
 
     for f, jf in zip(forces, jitted_forces):
-        assert torch.allclose(f, jf)
+        torch.testing.assert_close(f, jf)
 
 
 @pytest.mark.parametrize("is_training", [True, False])
@@ -90,9 +86,7 @@ def test_virial(is_training):
     )
 
     model = soap_bpnn.Model(capabilities)
-    systems = read_systems(
-        RESOURCES_PATH / "alchemical_reduced_10.xyz", dtype=torch.get_default_dtype()
-    )[:2]
+    systems = read_systems(RESOURCES_PATH / "alchemical_reduced_10.xyz")[:2]
 
     strains = [
         torch.eye(
@@ -143,7 +137,7 @@ def test_virial(is_training):
     jitted_virial = [-cell_gradient for cell_gradient in jitted_strain_gradients]
 
     for v, jv in zip(virial, jitted_virial):
-        assert torch.allclose(v, jv)
+        torch.testing.assert_close(v, jv)
 
 
 @pytest.mark.parametrize("is_training", [True, False])
@@ -162,9 +156,7 @@ def test_both(is_training):
     )
 
     model = soap_bpnn.Model(capabilities)
-    systems = read_systems(
-        RESOURCES_PATH / "alchemical_reduced_10.xyz", dtype=torch.get_default_dtype()
-    )[:2]
+    systems = read_systems(RESOURCES_PATH / "alchemical_reduced_10.xyz")[:2]
 
     # Here we re-create strains and systems, otherwise torch
     # complains that the graph has already beeen freed in the last grad call
@@ -216,4 +208,4 @@ def test_both(is_training):
     jitted_f_and_v = [-jitted_gradient for jitted_gradient in jitted_gradients]
 
     for fv, jfv in zip(f_and_v, jitted_f_and_v):
-        assert torch.allclose(fv, jfv)
+        torch.testing.assert_close(fv, jfv)

--- a/tox.ini
+++ b/tox.ini
@@ -63,9 +63,8 @@ deps =
 changedir = tests
 extras = soap-bpnn  # this model is used in the package tests
 allowlist_externals = bash
+commands_pre = bash {toxinidir}/tests/resources/generate-outputs.sh
 commands =
-    # generate model outputs for tests
-    bash {toxinidir}/tests/resources/generate-outputs.sh
     pytest \
         --cov={env_site_packages_dir}/metatensor --cov-append --cov-report= --import-mode=append \
         {[testenv]warning_options} \

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,10 @@ deps =
     pytest-cov
 changedir = tests
 extras = soap-bpnn  # this model is used in the package tests
+allowlist_externals = bash
 commands =
+    # generate model outputs for tests
+    bash {toxinidir}/tests/resources/generate-outputs.sh
     pytest \
         --cov={env_site_packages_dir}/metatensor --cov-append --cov-report= --import-mode=append \
         {[testenv]warning_options} \


### PR DESCRIPTION
Fixes #148 

This PR removes all calls of `set_default_dtype` and `get_default_dtype`. For now I am using the `.to()` method to move the model to the correct dtype. But is there also an option to initialize the model in the first place in the correct dtype?

The reveiled some issues that are also fixed within this PR

1. if a user changes the dtype for continue training the soap-bpnn would not work. Now the `dtype` of the model is set to the one of the dataset.
2.  similar for `eval`. There we adjust the loading dtype to the targets to the dtype  the exported model

## Additional changes
 - changed the default precision to 32 to match the torch one. We can also leave this at 64-bit?
 - replaced `assert torch.allclose` by the more verbose `torch.testing.assert_close`


# TODO
- [x] add an `eval` test for 64-bit and 32-bit exported models
- [x] add `__architecture_capabilities__ ` to each architecture indicating their supported types 
- [x] add `dtype` check to `check_datasets` function

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--155.org.readthedocs.build/en/155/

<!-- readthedocs-preview metatensor-models end -->