### PR TITLE
Fix SOAP feature count and sparsity in SOAP-BPNN

### DIFF
--- a/src/metatensor/models/experimental/soap_bpnn/model.py
+++ b/src/metatensor/models/experimental/soap_bpnn/model.py
@@ -237,7 +237,7 @@ class Model(torch.nn.Module):
             radial_basis={"Gto": {}}, **hypers["soap"]
         )
         soap_size = (
-            len(self.all_species) ** 2
+            (len(self.all_species) * (len(self.all_species) + 1) // 2)
             * hypers["soap"]["max_radial"] ** 2
             * (hypers["soap"]["max_angular"] + 1)
         )
@@ -251,13 +251,13 @@ class Model(torch.nn.Module):
             self.layernorm = torch.nn.Identity()
 
         self.bpnn = MLPMap(self.all_species, hypers_bpnn)
-        self.neighbor_species_1_labels = Labels(
-            names=["neighbor_1_type"],
-            values=torch.tensor(self.all_species).reshape(-1, 1),
-        )
-        self.neighbor_species_2_labels = Labels(
-            names=["neighbor_2_type"],
-            values=torch.tensor(self.all_species).reshape(-1, 1),
+
+        self.neighbor_species_labels = Labels(
+            names=["neighbor_1_type", "neighbor_2_type"],
+            values=torch.combinations(
+                torch.tensor(self.all_species, dtype=torch.int),
+                with_replacement=True,
+            ),
         )
 
         if hypers_bpnn["num_hidden_layers"] == 0:
@@ -283,10 +283,7 @@ class Model(torch.nn.Module):
 
         device = soap_features.block(0).values.device
         soap_features = soap_features.keys_to_properties(
-            self.neighbor_species_1_labels.to(device)
-        )
-        soap_features = soap_features.keys_to_properties(
-            self.neighbor_species_2_labels.to(device)
+            self.neighbor_species_labels.to(device)
         )
 
         soap_features = self.layernorm(soap_features)

--- a/src/metatensor/models/experimental/soap_bpnn/tests/test_regression.py
+++ b/src/metatensor/models/experimental/soap_bpnn/tests/test_regression.py
@@ -42,7 +42,7 @@ def test_regression_init():
         [systems_to_torch(system) for system in systems],
         {"U0": soap_bpnn.capabilities.outputs["U0"]},
     )
-    expected_output = torch.tensor([[0.0739], [0.0758], [0.1782], [-0.3517], [-0.3251]])
+    expected_output = torch.tensor([[0.3964], [0.0813], [0.0491], [0.2726], [0.4292]])
 
     torch.testing.assert_close(
         output["U0"].block().values, expected_output, rtol=1e-3, atol=1e-08
@@ -87,7 +87,7 @@ def test_regression_train():
     output = soap_bpnn(systems[:5], {"U0": soap_bpnn.capabilities.outputs["U0"]})
 
     expected_output = torch.tensor(
-        [[-40.3951], [-56.4275], [-76.4008], [-77.3751], [-93.4227]]
+        [[-40.4551], [-56.5427], [-76.3641], [-77.3653], [-93.4208]]
     )
 
     torch.testing.assert_close(


### PR DESCRIPTION
Thanks a lot @SanggyuChong for finding this bug.
The bug was harmless since the new features were filled with zeros, but it made the model twice as slow

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--164.org.readthedocs.build/en/164/

<!-- readthedocs-preview metatensor-models end -->