### PR TITLE
Sphinx Maintenance 

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -45,6 +45,11 @@ release = metatensor.models.__version__
 
 # -- General configuration ---------------------------------------------------
 
+# issue with the sphinx cache for sphinx >= 7.3 and sphinx-gallery 0.15.0
+# https://github.com/sphinx-gallery/sphinx-gallery/issues/1286
+# Remove the line below once a new version is relased
+suppress_warnings = ["config.cache"]
+
 
 def generate_examples():
     # we can not run sphinx-gallery in the same process as the normal sphinx, since they

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,9 @@ dependencies = [
     "ase",
     "torch",
     "hydra-core",
+    "metatensor-learn==0.2.1",
     "metatensor-operations==0.2.1",
     "metatensor-torch==0.3.0",
-    "metatensor-learn==0.2.1",
 ]
 
 keywords = ["machine learning", "molecular modeling"]


### PR DESCRIPTION
There is a current (and already fixed) issue with sphinx-gallery 0.15.0 and 7.3 which will raise a warning that we treat an error in our `docs` job. I suppress this warning until the next version is released.

I also removed the explicit import `torch` since metatensor knows best which torch we want and will also override whatever we give there.

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--173.org.readthedocs.build/en/173/

<!-- readthedocs-preview metatensor-models end -->