### PR TITLE
Loss improvements

### DIFF
--- a/src/metatensor/models/cli/conf/architecture/experimental.alchemical_model.yaml
+++ b/src/metatensor/models/cli/conf/architecture/experimental.alchemical_model.yaml
@@ -21,4 +21,4 @@ training:
   scheduler_factor: 0.8  
   log_interval: 10
   checkpoint_interval: 25
-  per_atom_targets: []
+  per_structure_targets: []

--- a/src/metatensor/models/cli/conf/architecture/experimental.soap_bpnn.yaml
+++ b/src/metatensor/models/cli/conf/architecture/experimental.soap_bpnn.yaml
@@ -29,4 +29,4 @@ training:
   log_interval: 10
   checkpoint_interval: 25
   fixed_composition_weights: {}
-  per_atom_targets: []
+  per_structure_targets: []

--- a/src/metatensor/models/cli/eval.py
+++ b/src/metatensor/models/cli/eval.py
@@ -167,7 +167,7 @@ def _eval_targets(
             all_predictions.append(batch_predictions)
 
     # Finalize the RMSEs
-    rmse_values = rmse_accumulator.finalize()
+    rmse_values = rmse_accumulator.finalize(not_per_atom=["positions_gradients"])
     # print the RMSEs with MetricLogger
     metric_logger = MetricLogger(
         model_capabilities=model.capabilities(),

--- a/src/metatensor/models/experimental/alchemical_model/tests/test_regression.py
+++ b/src/metatensor/models/experimental/alchemical_model/tests/test_regression.py
@@ -134,7 +134,7 @@ def test_regression_train():
     )
 
     expected_output = torch.tensor(
-        [[-123.0245], [-109.3167], [-129.6946], [-160.1561], [-138.4090]]
+        [[-126.6899], [-113.0781], [-135.8210], [-179.1740], [-149.5980]]
     )
 
     torch.testing.assert_close(

--- a/src/metatensor/models/experimental/alchemical_model/train.py
+++ b/src/metatensor/models/experimental/alchemical_model/train.py
@@ -239,15 +239,10 @@ def train(
                 is_training=True,
             )
 
-            # average by the number of atoms (if not disabled)
-            num_atoms = torch.tensor([len(s) for s in systems], device=device)
-            for target in targets.keys():
-                if target in per_structure_targets:
-                    continue
-                predictions[target] = divide_by_num_atoms(
-                    predictions[target], num_atoms
-                )
-                targets[target] = divide_by_num_atoms(targets[target], num_atoms)
+            # average by the number of atoms
+            predictions, targets = _average_by_num_atoms(
+                predictions, targets, systems, per_structure_targets
+            )
 
             train_loss_batch = loss_fn(predictions, targets)
             train_loss += train_loss_batch.item()
@@ -274,15 +269,10 @@ def train(
                 is_training=False,
             )
 
-            # average by the number of atoms (if not disabled)
-            num_atoms = torch.tensor([len(s) for s in systems], device=device)
-            for target in targets.keys():
-                if target in per_structure_targets:
-                    continue
-                predictions[target] = divide_by_num_atoms(
-                    predictions[target], num_atoms
-                )
-                targets[target] = divide_by_num_atoms(targets[target], num_atoms)
+            # average by the number of atoms
+            predictions, targets = _average_by_num_atoms(
+                predictions, targets, systems, per_structure_targets
+            )
 
             validation_loss_batch = loss_fn(predictions, targets)
             validation_loss += validation_loss_batch.item()
@@ -333,3 +323,15 @@ def train(
                 break
 
     return model
+
+
+def _average_by_num_atoms(predictions, targets, systems, per_structure_targets):
+    device = systems[0].device
+    num_atoms = torch.tensor([len(s) for s in systems], device=device)
+    for target in targets.keys():
+        if target in per_structure_targets:
+            continue
+        predictions[target] = divide_by_num_atoms(predictions[target], num_atoms)
+        targets[target] = divide_by_num_atoms(targets[target], num_atoms)
+
+    return predictions, targets

--- a/src/metatensor/models/experimental/alchemical_model/train.py
+++ b/src/metatensor/models/experimental/alchemical_model/train.py
@@ -254,7 +254,9 @@ def train(
             train_loss_batch.backward()
             optimizer.step()
             train_rmse_calculator.update(predictions, targets)
-        finalized_train_info = train_rmse_calculator.finalize()
+        finalized_train_info = train_rmse_calculator.finalize(
+            not_per_atom=["positions_gradients"] + per_structure_targets
+        )
 
         validation_loss = 0.0
         for batch in validation_dataloader:
@@ -285,7 +287,9 @@ def train(
             validation_loss_batch = loss_fn(predictions, targets)
             validation_loss += validation_loss_batch.item()
             validation_rmse_calculator.update(predictions, targets)
-        finalized_validation_info = validation_rmse_calculator.finalize()
+        finalized_validation_info = validation_rmse_calculator.finalize(
+            not_per_atom=["positions_gradients"] + per_structure_targets
+        )
 
         lr_scheduler.step(validation_loss)
 

--- a/src/metatensor/models/experimental/soap_bpnn/tests/test_regression.py
+++ b/src/metatensor/models/experimental/soap_bpnn/tests/test_regression.py
@@ -89,7 +89,7 @@ def test_regression_train():
     output = soap_bpnn(systems[:5], {"U0": soap_bpnn.capabilities.outputs["U0"]})
 
     expected_output = torch.tensor(
-        [[-40.4913], [-56.5962], [-76.5165], [-77.3447], [-93.4256]]
+        [[-40.6094], [-56.5482], [-76.5713], [-77.3526], [-93.4935]]
     )
 
     torch.testing.assert_close(

--- a/src/metatensor/models/experimental/soap_bpnn/train.py
+++ b/src/metatensor/models/experimental/soap_bpnn/train.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Optional, Union
 import torch
 from metatensor.learn.data import DataLoader
 from metatensor.learn.data.dataset import Dataset
-from metatensor.torch import TensorMap
 from metatensor.torch.atomistic import ModelCapabilities, ModelOutput
 
 from ...utils.composition import calculate_composition_weights
@@ -25,7 +24,7 @@ from ...utils.logging import MetricLogger
 from ...utils.loss import TensorMapDictLoss
 from ...utils.merge_capabilities import merge_capabilities
 from ...utils.metrics import RMSEAccumulator
-from ...utils.per_atom import average_block_by_num_atoms
+from ...utils.per_atom import divide_by_num_atoms
 from .model import DEFAULT_HYPERS, Model
 
 
@@ -224,7 +223,7 @@ def train(
     epochs_without_improvement = 0
 
     # per-atom targets:
-    per_atom_targets = hypers_training["per_atom_targets"]
+    per_structure_targets = hypers_training["per_structure_targets"]
 
     # Train the model:
     logger.info("Starting training")
@@ -249,23 +248,15 @@ def train(
                 is_training=True,
             )
 
-            # average by the number of atoms (if requested)
-            num_atoms = torch.tensor(
-                [len(s) for s in systems], device=device
-            ).unsqueeze(-1)
-            for pa_target in per_atom_targets:
-                predictions[pa_target] = TensorMap(
-                    predictions[pa_target].keys,
-                    [
-                        average_block_by_num_atoms(
-                            predictions[pa_target].block(), num_atoms
-                        )
-                    ],
+            # average by the number of atoms (if not disabled)
+            num_atoms = torch.tensor([len(s) for s in systems], device=device)
+            for target in targets.keys():
+                if target in per_structure_targets:
+                    continue
+                predictions[target] = divide_by_num_atoms(
+                    predictions[target], num_atoms
                 )
-                targets[pa_target] = TensorMap(
-                    targets[pa_target].keys,
-                    [average_block_by_num_atoms(targets[pa_target].block(), num_atoms)],
-                )
+                targets[target] = divide_by_num_atoms(targets[target], num_atoms)
 
             train_loss_batch = loss_fn(predictions, targets)
             train_loss += train_loss_batch.item()
@@ -289,23 +280,15 @@ def train(
                 is_training=False,
             )
 
-            # average by the number of atoms (if requested)
-            num_atoms = torch.tensor(
-                [len(s) for s in systems], device=device
-            ).unsqueeze(-1)
-            for pa_target in per_atom_targets:
-                predictions[pa_target] = TensorMap(
-                    predictions[pa_target].keys,
-                    [
-                        average_block_by_num_atoms(
-                            predictions[pa_target].block(), num_atoms
-                        )
-                    ],
+            # average by the number of atoms (if not disabled)
+            num_atoms = torch.tensor([len(s) for s in systems], device=device)
+            for target in targets.keys():
+                if target in per_structure_targets:
+                    continue
+                predictions[target] = divide_by_num_atoms(
+                    predictions[target], num_atoms
                 )
-                targets[pa_target] = TensorMap(
-                    targets[pa_target].keys,
-                    [average_block_by_num_atoms(targets[pa_target].block(), num_atoms)],
-                )
+                targets[target] = divide_by_num_atoms(targets[target], num_atoms)
 
             validation_loss_batch = loss_fn(predictions, targets)
             validation_loss += validation_loss_batch.item()

--- a/src/metatensor/models/experimental/soap_bpnn/train.py
+++ b/src/metatensor/models/experimental/soap_bpnn/train.py
@@ -248,15 +248,10 @@ def train(
                 is_training=True,
             )
 
-            # average by the number of atoms (if not disabled)
-            num_atoms = torch.tensor([len(s) for s in systems], device=device)
-            for target in targets.keys():
-                if target in per_structure_targets:
-                    continue
-                predictions[target] = divide_by_num_atoms(
-                    predictions[target], num_atoms
-                )
-                targets[target] = divide_by_num_atoms(targets[target], num_atoms)
+            # average by the number of atoms
+            predictions, targets = _average_by_num_atoms(
+                predictions, targets, systems, per_structure_targets
+            )
 
             train_loss_batch = loss_fn(predictions, targets)
             train_loss += train_loss_batch.item()
@@ -282,15 +277,10 @@ def train(
                 is_training=False,
             )
 
-            # average by the number of atoms (if not disabled)
-            num_atoms = torch.tensor([len(s) for s in systems], device=device)
-            for target in targets.keys():
-                if target in per_structure_targets:
-                    continue
-                predictions[target] = divide_by_num_atoms(
-                    predictions[target], num_atoms
-                )
-                targets[target] = divide_by_num_atoms(targets[target], num_atoms)
+            # average by the number of atoms
+            predictions, targets = _average_by_num_atoms(
+                predictions, targets, systems, per_structure_targets
+            )
 
             validation_loss_batch = loss_fn(predictions, targets)
             validation_loss += validation_loss_batch.item()
@@ -341,3 +331,15 @@ def train(
                 break
 
     return model
+
+
+def _average_by_num_atoms(predictions, targets, systems, per_structure_targets):
+    device = systems[0].device
+    num_atoms = torch.tensor([len(s) for s in systems], device=device)
+    for target in targets.keys():
+        if target in per_structure_targets:
+            continue
+        predictions[target] = divide_by_num_atoms(predictions[target], num_atoms)
+        targets[target] = divide_by_num_atoms(targets[target], num_atoms)
+
+    return predictions, targets

--- a/src/metatensor/models/experimental/soap_bpnn/train.py
+++ b/src/metatensor/models/experimental/soap_bpnn/train.py
@@ -263,7 +263,9 @@ def train(
             train_loss_batch.backward()
             optimizer.step()
             train_rmse_calculator.update(predictions, targets)
-        finalized_train_info = train_rmse_calculator.finalize()
+        finalized_train_info = train_rmse_calculator.finalize(
+            not_per_atom=["positions_gradients"] + per_structure_targets
+        )
 
         validation_loss = 0.0
         for batch in validation_dataloader:
@@ -293,7 +295,9 @@ def train(
             validation_loss_batch = loss_fn(predictions, targets)
             validation_loss += validation_loss_batch.item()
             validation_rmse_calculator.update(predictions, targets)
-        finalized_validation_info = validation_rmse_calculator.finalize()
+        finalized_validation_info = validation_rmse_calculator.finalize(
+            not_per_atom=["positions_gradients"] + per_structure_targets
+        )
 
         lr_scheduler.step(validation_loss)
 

--- a/src/metatensor/models/utils/evaluate_model.py
+++ b/src/metatensor/models/utils/evaluate_model.py
@@ -267,19 +267,3 @@ def _get_model_outputs(
         return model(
             systems, {key: _get_capabilities(model).outputs[key] for key in targets}
         )
-
-
-def _average_by_num_atoms(block: TensorBlock, num_atoms: torch.Tensor) -> TensorBlock:
-    """Taking the average values per atom of a `TensorBlock`."""
-
-    new_values = block.values / num_atoms
-    new_block = TensorBlock(
-        values=new_values,
-        samples=block.samples,
-        components=block.components,
-        properties=block.properties,
-    )
-    for param, gradient in block.gradients():
-        new_block.add_gradient(param, gradient)
-
-    return new_block

--- a/src/metatensor/models/utils/logging.py
+++ b/src/metatensor/models/utils/logging.py
@@ -102,19 +102,18 @@ class MetricLogger:
                         else:
                             new_key = f"force[{target_name} {metric}]"
                 elif "_strain_gradients" in key:
-                    # check if this is a virial/stress
+                    # check if this is a virial
                     target_name, metric = key.split(" ")
                     target_name = target_name[: -len("_strain_gradients")]
                     if (
                         self.model_capabilities.outputs[target_name].quantity
                         == "energy"
                     ):
-                        # if this is a virial/stress,
-                        # replace the ugly name with "virial/stress"
+                        # if this is a virial, replace the ugly name with "virial"
                         if self.only_one_energy:
-                            new_key = f"virial/stress {metric}"
+                            new_key = f"virial {metric}"
                         else:
-                            new_key = f"virial/stress[{target_name}] {metric}"
+                            new_key = f"virial[{target_name}] {metric}"
 
                 if name == "":
                     logging_string += f", {new_key}: "

--- a/src/metatensor/models/utils/metrics.py
+++ b/src/metatensor/models/utils/metrics.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple
+from typing import Dict, List, Tuple
 
 from metatensor.torch import TensorMap
 
@@ -47,11 +47,20 @@ class RMSEAccumulator:
                     + prediction_gradient.values.numel(),
                 )
 
-    def finalize(self) -> Dict[str, float]:
-        """Finalizes the accumulator and return the RMSE for each key."""
+    def finalize(self, not_per_atom: List[str]) -> Dict[str, float]:
+        """Finalizes the accumulator and return the RMSE for each key.
+
+        All keys will be returned as "{key} RMSE (per atom)" in the output dictionary,
+        unless ``key`` contains one or more of the strings in ``not_per_atom``,
+        in which case "{key} RMSE" will be returned.
+        """
 
         finalized_info = {}
         for key, value in self.information.items():
-            finalized_info[f"{key} RMSE"] = (value[0] / value[1]) ** 0.5
+            if any([s in key for s in not_per_atom]):
+                out_key = f"{key} RMSE"
+            else:
+                out_key = f"{key} RMSE (per atom)"
+            finalized_info[out_key] = (value[0] / value[1]) ** 0.5
 
         return finalized_info

--- a/src/metatensor/models/utils/per_atom.py
+++ b/src/metatensor/models/utils/per_atom.py
@@ -1,20 +1,50 @@
 import torch
-from metatensor.torch import TensorBlock
+from metatensor.torch import TensorBlock, TensorMap
 
 
-def average_block_by_num_atoms(
-    block: TensorBlock, num_atoms: torch.Tensor
-) -> TensorBlock:
-    """Takes the average values per atom of a `TensorBlock`."""
+def divide_by_num_atoms(tensor_map: TensorMap, num_atoms: torch.Tensor) -> TensorMap:
+    """Takes the average values per atom of a ``TensorMap``.
 
-    new_values = block.values / num_atoms
-    new_block = TensorBlock(
-        values=new_values,
-        samples=block.samples,
-        components=block.components,
-        properties=block.properties,
+    Since some quantities might already be per atom (e.g., atomic energies
+    or position gradients), this function only divides a block (or gradient
+    block) by the number of atoms if the block's samples do not contain
+    the "atom" key. In practice, this guarantees the desired behavior for
+    the majority of the cases, including energies, forces, and virials, where
+    the energies and virials should be divided by the number of atoms, while
+    the forces should not.
+    """
+
+    blocks = []
+    for block in tensor_map.blocks():
+        if "atom" in block.samples.names:
+            new_block = block
+        else:
+            values = block.values / num_atoms.view(
+                -1, *[1] * (len(block.values.shape) - 1)
+            )
+            new_block = TensorBlock(
+                values=values,
+                samples=block.samples,
+                components=block.components,
+                properties=block.properties,
+            )
+            for gradient_name, gradient in block.gradients():
+                if "atom" in gradient.samples.names:
+                    new_gradient = gradient
+                else:
+                    values = gradient.values / num_atoms.view(
+                        -1, *[1] * (len(gradient.values.shape) - 1)
+                    )
+                    new_gradient = TensorBlock(
+                        values=values,
+                        samples=gradient.samples,
+                        components=gradient.components,
+                        properties=gradient.properties,
+                    )
+                new_block.add_gradient(gradient_name, new_gradient)
+        blocks.append(new_block)
+
+    return TensorMap(
+        keys=tensor_map.keys,
+        blocks=blocks,
     )
-    for param, gradient in block.gradients():
-        new_block.add_gradient(param, gradient)
-
-    return new_block

--- a/tests/utils/test_metrics.py
+++ b/tests/utils/test_metrics.py
@@ -59,7 +59,7 @@ def test_rmse_accumulator(tensor_map_with_grad_1, tensor_map_with_grad_2):
     assert rmse_accumulator.information["energy"][1] == 30
     assert rmse_accumulator.information["energy_gradient_gradients"][1] == 30
 
-    rmses = rmse_accumulator.finalize()
+    rmses = rmse_accumulator.finalize(not_per_atom=["gradient_gradients"])
 
-    assert "energy RMSE" in rmses
+    assert "energy RMSE (per atom)" in rmses
     assert "energy_gradient_gradients RMSE" in rmses

--- a/tests/utils/test_per_atom.py
+++ b/tests/utils/test_per_atom.py
@@ -1,0 +1,62 @@
+import torch
+from metatensor.torch import Labels, TensorBlock, TensorMap
+
+from metatensor.models.utils.per_atom import divide_by_num_atoms
+
+
+def test_divide_by_num_atoms():
+    """Tests the divide_by_num_atoms function."""
+
+    n_atoms = torch.tensor([1, 2, 3])
+
+    block = TensorBlock(
+        values=torch.tensor([[1.0], [2.0], [3.0]]),
+        samples=Labels.range("samples", 3),
+        components=[],
+        properties=Labels("energy", torch.tensor([[0]])),
+    )
+
+    block.add_gradient(
+        "position",
+        TensorBlock(
+            values=torch.tensor([[1.0], [2.0], [3.0]]),
+            samples=Labels(
+                names=["sample", "atom"],
+                values=torch.stack(
+                    [
+                        torch.tensor([0, 1, 2]),
+                        torch.tensor([0, 0, 0]),
+                    ],
+                    dim=1,
+                ),
+            ),
+            components=[],
+            properties=Labels("energy", torch.tensor([[0]])),
+        ),
+    )
+    block.add_gradient(
+        "strain",
+        TensorBlock(
+            values=torch.tensor([[1.0], [2.0], [3.0]]),
+            samples=Labels.range("sample", 3),
+            components=[],
+            properties=Labels("energy", torch.tensor([[0]])),
+        ),
+    )
+
+    tensor_map = TensorMap(keys=Labels.single(), blocks=[block])
+
+    tensor_map = divide_by_num_atoms(tensor_map, n_atoms)
+
+    # energies and virials should be divided by the number of atoms
+    assert torch.allclose(tensor_map.block().values, torch.tensor([1.0, 1.0, 1.0]))
+    assert torch.allclose(
+        tensor_map.block().gradient("strain").values,
+        torch.tensor([[1.0], [1.0], [1.0]]),
+    )
+
+    # forces should not be
+    assert torch.allclose(
+        tensor_map.block().gradient("position").values,
+        torch.tensor([[1.0], [2.0], [3.0]]),
+    )


### PR DESCRIPTION
This PR aims to improve our handling of losses.
The changes are:
- we make it clear in the logs that we always compute errors on the virial (and not the stress, even if the user provides stresses)
- we weight energies and virials by the number of atoms by default (this is correct statistically), with an option to disable the weighting
- we show if energy and virial errors are per-atom in the logs

Left for a follow-up PR (since it requires changes in I/O): different weighting of energies, forces, virials.

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--177.org.readthedocs.build/en/177/

<!-- readthedocs-preview metatensor-models end -->