### PR TITLE
remove `override_options` from train command

### DIFF
--- a/src/metatensor/models/cli/train.py
+++ b/src/metatensor/models/cli/train.py
@@ -6,7 +6,7 @@ import os
 import random
 from importlib.util import find_spec
 from pathlib import Path
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 import numpy as np
 import torch
@@ -120,11 +120,10 @@ def check_architecture_name(name: str) -> None:
 
 
 def train_model(
-    options: DictConfig,
+    options: Union[DictConfig, Dict],
     output: str = "model.pt",
     checkpoint_dir: Union[str, Path] = ".",
     continue_from: Optional[str] = None,
-    override_options: Optional[DictConfig] = None,
 ) -> None:
     """Train an atomistic machine learning model using provided ``options``.
 
@@ -139,7 +138,6 @@ def train_model(
     :param checkpoint_dir: Path to save checkpoints and other intermediate output files
         like the fully expanded training options for a later restart.
     :param continue_from: File to continue training from.
-    :param override_options: Extra options to override values in ``options``.
     """
     try:
         architecture_name = options["architecture"]["name"]
@@ -160,12 +158,8 @@ def train_model(
             )
         }
     )
-    if override_options is None:
-        override_options = OmegaConf.create({})
 
-    options = OmegaConf.merge(
-        base_options, architecture_options, options, override_options
-    )
+    options = OmegaConf.merge(base_options, architecture_options, options)
 
     ###########################
     # PROCESS BASE PARAMETERS #


### PR DESCRIPTION
The `override_options` parameter in the (Python) `train` function is very "unpythonic". If you want to use the function from the Python interpreter you usually don't have extra override options. You override the your hypers in advance i.e by:

```python
hypers["my_parametrer"] = "foo"
```

or 
```python
hypers.update({"my_parametrer": "foo"})
```

Therefore, I see no need to offer such an option on the Python level.

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--183.org.readthedocs.build/en/183/

<!-- readthedocs-preview metatensor-models end -->