### PR TITLE
Remove milliseconds from logger

### DIFF
--- a/src/metatensor/models/utils/logging.py
+++ b/src/metatensor/models/utils/logging.py
@@ -189,7 +189,7 @@ def setup_logging(
             format += ":{filename}:{funcName}:{lineno}"
         format += " - {message}"
 
-        formatter = logging.Formatter(format, style="{")
+        formatter = logging.Formatter(format, datefmt="%Y-%m-%d %H:%M:%S", style="{")
         handlers: List[Union[logging.StreamHandler, logging.FileHandler]] = []
 
         stream_handler = logging.StreamHandler(sys.stdout)
@@ -202,13 +202,7 @@ def setup_logging(
             file_handler.setFormatter(formatter)
             handlers.append(file_handler)
 
-        logging.basicConfig(
-            format=format,
-            datefmt="%Y-%m-%d %H:%M:%S",
-            handlers=handlers,
-            level=level,
-            style="{",
-        )
+        logging.basicConfig(format=format, handlers=handlers, level=level, style="{")
 
         if logfile:
             logobj.info(f"This log is also available in {str(logfile)!r}.")

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -6,7 +6,7 @@ from metatensor.models.utils.logging import setup_logging
 
 def assert_log_entry(logtext: str, loglevel: str, message: str) -> None:
     pattern = (
-        r"\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}\]\["
+        r"\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\]\["
         + re.escape(loglevel.strip())
         + r"\] - "
         + re.escape(message)


### PR DESCRIPTION
Fix #180 and results in a log like this:

```
[2024-05-16 09:50:45][INFO] - This log is also available in 'outputs/2024-05-16/09-50-45/train.log'.
[2024-05-16 09:50:45][INFO] - random seed of this run is 3262385442
[2024-05-16 09:50:45][INFO] - Setting up training set
[2024-05-16 09:50:45][WARNING] - No Forces found in section 'energy'. Continue without forces!
[2024-05-16 09:50:45][WARNING] - No Stress found in section 'energy'. Continue without stress!
[2024-05-16 09:50:45][INFO] - Setting up test set
[2024-05-16 09:50:45][INFO] - Setting up validation set
[2024-05-16 09:50:45][INFO] - Setting up model
[2024-05-16 09:50:45][INFO] - Calling architecture trainer
[2024-05-16 09:50:45][INFO] - Checking datasets for consistency
[2024-05-16 09:50:45][INFO] - training on device cpu with dtype torch.float32
[2024-05-16 09:50:45][INFO] - Calculating composition weights
[2024-05-16 09:50:45][INFO] - Setting up data loaders
[2024-05-16 09:50:46][INFO] - Starting training
```

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--184.org.readthedocs.build/en/184/

<!-- readthedocs-preview metatensor-models end -->