### PR TITLE
Ignore sphinx-linting of the docs/src/examples folder

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,8 @@ commands =
     isort --check-only --diff {[testenv]lint_folders}
     mypy --check-untyped-defs src/metatensor
     sphinx-lint --enable line-too-long --max-line-length 88 \
-        -i {[testenv]lint_folders} "{toxinidir}/README.rst"
+        -i "{toxinidir}/docs/src/examples" \
+        {[testenv]lint_folders} "{toxinidir}/README.rst"
 
 [testenv:format]
 description = Abuse tox to do actual formatting on all files.


### PR DESCRIPTION
Otherwise you get sphinx errors for the auto generated `.rst` files of `sphinx-gallery` which do not follow the linting rules.

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--187.org.readthedocs.build/en/187/

<!-- readthedocs-preview metatensor-models end -->