### PR TITLE
Change model name in example

### DIFF
--- a/examples/ase/run_ase.py
+++ b/examples/ase/run_ase.py
@@ -15,7 +15,7 @@ The model was trained using the following training options.
 .. literalinclude:: options.yaml
    :language: yaml
 
-You can use the pretrained and exported :download:`model <exported-model.pt>`
+You can use the pretrained and exported :download:`model <model.pt>`
 or train the model yourself with
 
 .. literalinclude:: train.sh
@@ -82,7 +82,7 @@ ase.md.velocitydistribution.MaxwellBoltzmannDistribution(atoms, temperature_K=30
 # We now register our exported model as the energy calculator to obtain energies and
 # forces.
 
-atoms.calc = MetatensorCalculator("exported-model.pt")
+atoms.calc = MetatensorCalculator("model.pt")
 
 # %%
 #


### PR DESCRIPTION
This should fix the docs issue. I think "model.pt" is even the better name because for us the suffix `.pt` means that this is already exported.