### PR TITLE
Remove sphinx-gallery hot-fix

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -45,11 +45,6 @@ release = metatensor.models.__version__
 
 # -- General configuration ---------------------------------------------------
 
-# issue with the sphinx cache for sphinx >= 7.3 and sphinx-gallery 0.15.0
-# https://github.com/sphinx-gallery/sphinx-gallery/issues/1286
-# Remove the line below once a new version is relased
-suppress_warnings = ["config.cache"]
-
 
 def generate_examples():
     # we can not run sphinx-gallery in the same process as the normal sphinx, since they


### PR DESCRIPTION
A new version (0.16) of sphinx-gallery was released and the hot-fix isn't necessary anymore.

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--219.org.readthedocs.build/en/219/

<!-- readthedocs-preview metatensor-models end -->