### PR TITLE
Set codecov target to 90% andsShow codecov patch diff

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,8 +2,10 @@ coverage:
   status:
     project:
       default:
-        target: 80%
-    patch: off
+        target: 90%
+    patch:
+      default:
+        target: 90%
   ignore:
      - "tests/.*"
      - "examples/.*"


### PR DESCRIPTION
I think patch difference can be useful especially because we try target the 95 % :-)

<!-- readthedocs-preview metatensor-models start -->
----
📚 Documentation preview 📚: https://metatensor-models--221.org.readthedocs.build/en/221/

<!-- readthedocs-preview metatensor-models end -->